### PR TITLE
Detect and apply dark theme on Windows and macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ serde_json = "1.0"
 [dependencies.system76_ectool]
 version = "0.2.1"
 features = ["hidapi", "std"]
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winreg = "0.7"


### PR DESCRIPTION
I tested on both Windows and macOS. Before this PR, Adwaita light is always used. After, Adwaita dark is used if the theme is set to dark.