### PR TITLE
Add color/brightness to daemon, refactor daemon using macro magic, and use KeyboardColorButton in configurator

### DIFF
--- a/src/application/keyboard.rs
+++ b/src/application/keyboard.rs
@@ -16,8 +16,9 @@ use std::{
     },
 };
 
-use crate::color::Rgb;
 use crate::daemon::Daemon;
+use crate::keyboard::Keyboard as ColorKeyboard;
+use crate::keyboard_color_button::KeyboardColorButton;
 use super::key::Key;
 use super::picker::Picker;
 use super::rect::Rect;
@@ -456,18 +457,14 @@ button {
             gdk::RGBA::black()
         };
 
-        let color_button = gtk::ColorButton::with_rgba(&color_rgba);
-        color_button.set_halign(gtk::Align::Fill);
-        let kb = self.clone();
-        color_button.connect_color_set(move |this| {
-            let rgba = this.get_rgba();
-            let color = Rgb::from_floats(rgba.red, rgba.green, rgba.blue);
-            if let Some(ref daemon) = kb.daemon_opt {
-                if let Err(err) = daemon.set_color(kb.daemon_board, color) {
-                    eprintln!("{}", err);
-                }
-            }
-        });
+        let color_keyboard = if let Some(ref daemon) = self.daemon_opt {
+            ColorKeyboard::new_daemon(daemon.clone(), self.daemon_board)
+        } else {
+
+            ColorKeyboard::new_dummy()
+        };
+        let color_button = KeyboardColorButton::new(color_keyboard).widget().clone();
+        color_button.set_valign(gtk::Align::Center);
 
         for page in &[
             "Layer 1",

--- a/src/application/keyboard.rs
+++ b/src/application/keyboard.rs
@@ -411,7 +411,7 @@ button {
 
         let max_brightness = if let Some(ref daemon) = self.daemon_opt {
             let mut daemon = daemon.borrow_mut();
-            match daemon.max_brightness() {
+            match daemon.max_brightness(self.daemon_board) {
                 Ok(value) => value as f64,
                 Err(err) => {
                     eprintln!("{}", err);
@@ -432,7 +432,7 @@ button {
             let value = this.get_value() as i32;
             if let Some(ref daemon) = kb.daemon_opt {
                 let mut daemon = daemon.borrow_mut();
-                if let Err(err) = daemon.set_brightness(value) {
+                if let Err(err) = daemon.set_brightness(kb.daemon_board, value) {
                     eprintln!("{}", err);
                 }
             }
@@ -447,7 +447,7 @@ button {
 
         let color_rgba = if let Some(ref daemon) = self.daemon_opt {
             let mut daemon = daemon.borrow_mut();
-            match daemon.color() {
+            match daemon.color(self.daemon_board) {
                 Ok(value) => {
                     let (red, green, blue) = value.to_floats();
                     gdk::RGBA { red, green, blue, alpha: 1. }
@@ -469,7 +469,7 @@ button {
             let color = Rgb::from_floats(rgba.red, rgba.green, rgba.blue);
             if let Some(ref daemon) = kb.daemon_opt {
                 let mut daemon = daemon.borrow_mut();
-                if let Err(err) = daemon.set_color(color) {
+                if let Err(err) = daemon.set_color(kb.daemon_board, color) {
                     eprintln!("{}", err);
                 }
             }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,7 +1,6 @@
 use cascade::cascade;
 use gio::prelude::*;
 use gtk::prelude::*;
-use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::daemon::{Daemon, DaemonClient, daemon_server};
@@ -44,8 +43,8 @@ fn main_keyboard(app: &gtk::Application, keyboard: Rc<Keyboard>) {
     });
 }
 
-fn main_app(app: &gtk::Application, daemon: Rc<RefCell<dyn Daemon>>) {
-    let boards = daemon.borrow_mut().boards().expect("Failed to load boards");
+fn main_app(app: &gtk::Application, daemon: Rc<dyn Daemon>) {
+    let boards = daemon.boards().expect("Failed to load boards");
     let i = 0;
     if let Some(board) = boards.get(i) {
         if let Some(keyboard) = Keyboard::new_board(board, Some(daemon), i) {
@@ -63,7 +62,7 @@ fn main_app(app: &gtk::Application, daemon: Rc<RefCell<dyn Daemon>>) {
 }
 
 #[cfg(target_os = "linux")]
-fn with_daemon<F: Fn(Rc<RefCell<dyn Daemon>>)>(f: F) {
+fn with_daemon<F: Fn(Rc<dyn Daemon>)>(f: F) {
     use std::{
         process::{
             Command,
@@ -74,7 +73,7 @@ fn with_daemon<F: Fn(Rc<RefCell<dyn Daemon>>)>(f: F) {
     if unsafe { libc::geteuid() == 0 } {
         eprintln!("Already running as root");
         let server = daemon_server().expect("Failed to create server");
-        f(Rc::new(RefCell::new(server)));
+        f(Rc::new(server));
         return;
     }
 
@@ -96,7 +95,7 @@ fn with_daemon<F: Fn(Rc<RefCell<dyn Daemon>>)>(f: F) {
     let stdin = child.stdin.take().expect("Failed to get stdin of daemon");
     let stdout = child.stdout.take().expect("Failed to get stdout of daemon");
 
-    f(Rc::new(RefCell::new(DaemonClient::new(stdout, stdin))));
+    f(Rc::new(DaemonClient::new(stdout, stdin)));
 
     let status = child.wait().expect("Failed to wait for daemon");
     if ! status.success() {

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -104,9 +104,9 @@ fn with_daemon<F: Fn(Rc<dyn Daemon>)>(f: F) {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn with_daemon<F: Fn(Box<dyn Daemon>)>(f: F) {
+fn with_daemon<F: Fn(Rc<dyn Daemon>)>(f: F) {
     let server = daemon_server().expect("Failed to create server");
-    f(Box::new(server));
+    f(Rc::new(server));
 }
 
 #[cfg(target_os = "macos")]

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,4 +1,5 @@
 use palette::{Component, IntoColor, RgbHue};
+use serde::{Serialize, Deserialize};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Hs {
@@ -22,7 +23,7 @@ impl Hs {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Rgb {
     /// Red
     pub r: u8,
@@ -35,6 +36,10 @@ pub struct Rgb {
 impl Rgb {
     pub fn new(r: u8, g: u8, b: u8) -> Self {
         Self { r, g, b }
+    }
+
+    pub fn from_floats(r: f64, g: f64, b: f64) -> Self {
+        Self { r: r.convert(), g: g.convert(), b: b.convert() }
     }
 
     pub fn to_floats(self) -> (f64, f64, f64) {

--- a/src/daemon/client.rs
+++ b/src/daemon/client.rs
@@ -8,6 +8,7 @@ use std::{
     },
 };
 
+use crate::color::Rgb;
 use super::{
     err_str,
     Daemon,
@@ -56,6 +57,26 @@ impl<R: Read, W: Write> Daemon for DaemonClient<R, W> {
 
     fn keymap_set(&mut self, board: usize, layer: u8, output: u8, input: u8, value: u16) -> Result<(), String> {
         self.command(DaemonCommand::KeymapSet { board, layer, output, input, value })
+    }
+
+    fn color(&mut self) -> Result<Rgb, String> {
+        self.command(DaemonCommand::Color)
+    }
+
+    fn set_color(&mut self, color: Rgb) -> Result<(), String> {
+        self.command(DaemonCommand::SetColor { color })
+    }
+
+    fn max_brightness(&mut self) -> Result<i32, String> {
+        self.command(DaemonCommand::MaxBrightness)
+    }
+
+    fn brightness(&mut self) -> Result<i32, String> {
+        self.command(DaemonCommand::Brightness)
+    }
+
+    fn set_brightness(&mut self, brightness: i32) -> Result<(), String> {
+        self.command(DaemonCommand::SetBrightness { brightness })
     }
 }
 

--- a/src/daemon/client.rs
+++ b/src/daemon/client.rs
@@ -1,4 +1,3 @@
-use serde::de::DeserializeOwned;
 use std::{
     io::{
         BufRead,
@@ -8,12 +7,11 @@ use std::{
     },
 };
 
-use crate::color::Rgb;
 use super::{
     err_str,
-    Daemon,
+    DaemonClientTrait,
     DaemonCommand,
-    DaemonResult,
+    DaemonResponse,
 };
 
 pub struct DaemonClient<R: Read, W: Write> {
@@ -28,60 +26,22 @@ impl<R: Read, W: Write> DaemonClient<R, W> {
             write,
         }
     }
+}
 
-    fn command<T: DeserializeOwned>(&mut self, command: DaemonCommand) -> Result<T, String> {
+impl<R: std::io::Read, W: std::io::Write> DaemonClientTrait for DaemonClient<R, W> {
+    fn send_command(&mut self, command: DaemonCommand) -> Result<DaemonResponse, String> {
         let mut command_json = serde_json::to_string(&command).map_err(err_str)?;
         command_json.push('\n');
         self.write.write_all(command_json.as_bytes()).map_err(err_str)?;
 
-        let mut result_json = String::new();
-        self.read.read_line(&mut result_json).map_err(err_str)?;
-        let result = serde_json::from_str::<DaemonResult>(&result_json).map_err(err_str)?;
-        match result {
-            DaemonResult::Ok { ok } => {
-                serde_json::from_reader(ok.as_bytes()).map_err(err_str)
-            },
-            DaemonResult::Err { err } => Err(err),
-        }
-    }
-}
-
-impl<R: Read, W: Write> Daemon for DaemonClient<R, W> {
-    fn boards(&mut self) -> Result<Vec<String>, String> {
-        self.command(DaemonCommand::Boards)
-    }
-
-    fn keymap_get(&mut self, board: usize, layer: u8, output: u8, input: u8) -> Result<u16, String> {
-        self.command(DaemonCommand::KeymapGet { board, layer, output, input })
-    }
-
-    fn keymap_set(&mut self, board: usize, layer: u8, output: u8, input: u8, value: u16) -> Result<(), String> {
-        self.command(DaemonCommand::KeymapSet { board, layer, output, input, value })
-    }
-
-    fn color(&mut self) -> Result<Rgb, String> {
-        self.command(DaemonCommand::Color)
-    }
-
-    fn set_color(&mut self, color: Rgb) -> Result<(), String> {
-        self.command(DaemonCommand::SetColor { color })
-    }
-
-    fn max_brightness(&mut self) -> Result<i32, String> {
-        self.command(DaemonCommand::MaxBrightness)
-    }
-
-    fn brightness(&mut self) -> Result<i32, String> {
-        self.command(DaemonCommand::Brightness)
-    }
-
-    fn set_brightness(&mut self, brightness: i32) -> Result<(), String> {
-        self.command(DaemonCommand::SetBrightness { brightness })
+        let mut response_json = String::new();
+        self.read.read_line(&mut response_json).map_err(err_str)?;
+        serde_json::from_str(&response_json).map_err(err_str)?
     }
 }
 
 impl<R: Read, W: Write> Drop for DaemonClient<R, W> {
     fn drop(&mut self) {
-        let _ = self.command::<()>(DaemonCommand::Exit);
+        let _ = self.send_command(DaemonCommand::exit{});
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -10,18 +10,18 @@ pub use self::server::DaemonServer;
 mod server;
 
 pub trait DaemonClientTrait {
-    fn send_command(&mut self, command: DaemonCommand) -> Result<DaemonResponse, String>;
+    fn send_command(&self, command: DaemonCommand) -> Result<DaemonResponse, String>;
 }
 
 // Define Daemon trait, DaemonCommand enum, and DaemonResponse enum
 macro_rules! commands {
-    ( $( fn $func:ident(&mut self $(,)? $( $arg:ident: $type:ty ),*) -> Result<$ret:ty, String>; )* ) => {
+    ( $( fn $func:ident(&self $(,)? $( $arg:ident: $type:ty ),*) -> Result<$ret:ty, String>; )* ) => {
         pub trait Daemon {
         $(
-            fn $func(&mut self, $( $arg: $type ),*) -> Result<$ret, String>;
+            fn $func(&self, $( $arg: $type ),*) -> Result<$ret, String>;
         )*
 
-            fn dispatch_command_to_method(&mut self, command: DaemonCommand) -> Result<DaemonResponse, String> {
+            fn dispatch_command_to_method(&self, command: DaemonCommand) -> Result<DaemonResponse, String> {
                 match command {
                 $(
                     DaemonCommand::$func{$( $arg ),*} => {
@@ -52,7 +52,7 @@ macro_rules! commands {
 
         impl<T: DaemonClientTrait> Daemon for T {
         $(
-            fn $func(&mut self, $( $arg: $type ),*) -> Result<$ret, String> {
+            fn $func(&self, $( $arg: $type ),*) -> Result<$ret, String> {
                 let res = self.send_command(DaemonCommand::$func{$( $arg ),*});
                 match res {
                     Ok(DaemonResponse::$func(ret)) => Ok(ret),
@@ -66,15 +66,15 @@ macro_rules! commands {
 }
 
 commands! {
-    fn boards(&mut self) -> Result<Vec<String>, String>;
-    fn keymap_get(&mut self, board: usize, layer: u8, output: u8, input: u8) -> Result<u16, String>;
-    fn keymap_set(&mut self, board: usize, layer: u8, output: u8, input: u8, value: u16) -> Result<(), String>;
-    fn color(&mut self, board: usize) -> Result<Rgb, String>;
-    fn set_color(&mut self, board: usize, color: Rgb) -> Result<(), String>;
-    fn max_brightness(&mut self, board: usize) -> Result<i32, String>;
-    fn brightness(&mut self, board: usize) -> Result<i32, String>;
-    fn set_brightness(&mut self, board: usize, brightness: i32) -> Result<(), String>;
-    fn exit(&mut self) -> Result<(), String>;
+    fn boards(&self) -> Result<Vec<String>, String>;
+    fn keymap_get(&self, board: usize, layer: u8, output: u8, input: u8) -> Result<u16, String>;
+    fn keymap_set(&self, board: usize, layer: u8, output: u8, input: u8, value: u16) -> Result<(), String>;
+    fn color(&self, board: usize) -> Result<Rgb, String>;
+    fn set_color(&self, board: usize, color: Rgb) -> Result<(), String>;
+    fn max_brightness(&self, board: usize) -> Result<i32, String>;
+    fn brightness(&self, board: usize) -> Result<i32, String>;
+    fn set_brightness(&self, board: usize, brightness: i32) -> Result<(), String>;
+    fn exit(&self) -> Result<(), String>;
 }
 
 fn err_str<E: std::fmt::Debug>(err: E) -> String {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::io;
 
+use crate::color::Rgb;
+
 pub use self::client::DaemonClient;
 mod client;
 
@@ -11,6 +13,11 @@ pub trait Daemon {
     fn boards(&mut self) -> Result<Vec<String>, String>;
     fn keymap_get(&mut self, board: usize, layer: u8, output: u8, input: u8) -> Result<u16, String>;
     fn keymap_set(&mut self, board: usize, layer: u8, output: u8, input: u8, value: u16) -> Result<(), String>;
+    fn color(&mut self) -> Result<Rgb, String>;
+    fn set_color(&mut self, color: Rgb) -> Result<(), String>;
+    fn max_brightness(&mut self) -> Result<i32, String>;
+    fn brightness(&mut self) -> Result<i32, String>;
+    fn set_brightness(&mut self, brightness: i32) -> Result<(), String>;
 }
 
 fn err_str<E: std::fmt::Debug>(err: E) -> String {
@@ -23,6 +30,11 @@ enum DaemonCommand {
     Boards,
     KeymapGet { board: usize, layer: u8, output: u8, input: u8 },
     KeymapSet { board: usize, layer: u8, output: u8, input: u8, value: u16 },
+    MaxBrightness,
+    Brightness,
+    Color,
+    SetBrightness { brightness: i32 },
+    SetColor { color: Rgb },
     Exit,
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -69,11 +69,11 @@ commands! {
     fn boards(&mut self) -> Result<Vec<String>, String>;
     fn keymap_get(&mut self, board: usize, layer: u8, output: u8, input: u8) -> Result<u16, String>;
     fn keymap_set(&mut self, board: usize, layer: u8, output: u8, input: u8, value: u16) -> Result<(), String>;
-    fn color(&mut self) -> Result<Rgb, String>;
-    fn set_color(&mut self, color: Rgb) -> Result<(), String>;
-    fn max_brightness(&mut self) -> Result<i32, String>;
-    fn brightness(&mut self) -> Result<i32, String>;
-    fn set_brightness(&mut self, brightness: i32) -> Result<(), String>;
+    fn color(&mut self, board: usize) -> Result<Rgb, String>;
+    fn set_color(&mut self, board: usize, color: Rgb) -> Result<(), String>;
+    fn max_brightness(&mut self, board: usize) -> Result<i32, String>;
+    fn brightness(&mut self, board: usize) -> Result<i32, String>;
+    fn set_brightness(&mut self, board: usize, brightness: i32) -> Result<(), String>;
     fn exit(&mut self) -> Result<(), String>;
 }
 

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -11,7 +11,6 @@ use std::{
         Read,
         Write,
     },
-    process,
     str,
     time::Duration,
 };
@@ -250,6 +249,7 @@ impl<R: Read, W: Write> Daemon for DaemonServer<R, W> {
     }
 
     fn exit(&mut self) -> Result<(), String> {
-        process::exit(0);
+        self.running = false;
+        Ok(())
     }
 }

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -182,7 +182,7 @@ impl<R: Read, W: Write> Daemon for DaemonServer<R, W> {
         }
     }
 
-    fn color(&mut self) -> Result<Rgb, String> {
+    fn color(&mut self, board: usize) -> Result<Rgb, String> {
         let path = "/sys/class/leds/system76_acpi::kbd_backlight/color";
         match fs::read_to_string(&path) {
             Ok(string) => {
@@ -196,7 +196,7 @@ impl<R: Read, W: Write> Daemon for DaemonServer<R, W> {
         }
     }
 
-    fn set_color(&mut self, color: Rgb) -> Result<(), String> {
+    fn set_color(&mut self, board: usize, color: Rgb) -> Result<(), String> {
         let path = "/sys/class/leds/system76_acpi::kbd_backlight/color";
         match fs::write(path, &color.to_string()) {
             Ok(()) => Ok(()),
@@ -205,7 +205,7 @@ impl<R: Read, W: Write> Daemon for DaemonServer<R, W> {
 
     }
 
-    fn max_brightness(&mut self) -> Result<i32, String> {
+    fn max_brightness(&mut self, board: usize) -> Result<i32, String> {
         let path = "/sys/class/leds/system76_acpi::kbd_backlight/max_brightness";
         match fs::read_to_string(&path) {
             Ok(string) => {
@@ -223,7 +223,7 @@ impl<R: Read, W: Write> Daemon for DaemonServer<R, W> {
         }
     }
 
-    fn brightness(&mut self) -> Result<i32, String> {
+    fn brightness(&mut self, board: usize) -> Result<i32, String> {
         let path = "/sys/class/leds/system76_acpi::kbd_backlight/brightness";
         match fs::read_to_string(&path) {
             Ok(string) => {
@@ -241,7 +241,7 @@ impl<R: Read, W: Write> Daemon for DaemonServer<R, W> {
         }
     }
 
-    fn set_brightness(&mut self, brightness: i32) -> Result<(), String> {
+    fn set_brightness(&mut self, board: usize, brightness: i32) -> Result<(), String> {
         let path = "/sys/class/leds/system76_acpi::kbd_backlight/brightness";
         match fs::write(path, &format!("{}", brightness)) {
             Ok(()) => Ok(()),


### PR DESCRIPTION
The daemon currently sets color/brightness through sysfs. That will have to be updated to use ectool.

Adding methods to the daemon seems like rather a pain (needs to be added in 4 places), so I've updated it to use some `macro_rules!` magic. (I wish there were a nice common rpc crate that could be used here, but nothing quite fits). Not perfect, but I think this makes things a bit easier to maintain.

The implementation in `src/keyboard.rs` is a bit of a mess (the previous code worked well for dbus, and a dummy implementation). That may need to be replaced with something cleaner, but this is fine for now.

The UI for adding/removing colors doesn't quite work as intended because it should be persisted (https://github.com/system76/ec/issues/109).