### PR TITLE
improv: Display message when firmware doesn't support keymap API

### DIFF
--- a/backend/src/daemon/dummy.rs
+++ b/backend/src/daemon/dummy.rs
@@ -67,6 +67,10 @@ impl Daemon for DaemonDummy {
         Ok(self.board(board)?.name.clone())
     }
 
+    fn version(&self, _board: BoardId) -> Result<String, String> {
+        Ok("1970-01-01-deadbee".to_string())
+    }
+
     fn is_fake(&self) -> bool {
         true
     }

--- a/backend/src/daemon/mod.rs
+++ b/backend/src/daemon/mod.rs
@@ -110,6 +110,7 @@ macro_rules! commands {
 commands! {
     fn boards(&self) -> Result<Vec<BoardId>, String>;
     fn model(&self, board: BoardId) -> Result<String, String>;
+    fn version(&self, board: BoardId) -> Result<String, String>;
     fn refresh(&self) -> Result<(), String>;
     fn keymap_get(&self, board: BoardId, layer: u8, output: u8, input: u8) -> Result<u16, String>;
     fn keymap_set(&self, board: BoardId, layer: u8, output: u8, input: u8, value: u16) -> Result<(), String>;

--- a/backend/src/daemon/s76power.rs
+++ b/backend/src/daemon/s76power.rs
@@ -85,6 +85,10 @@ impl Daemon for DaemonS76Power {
         Ok("system76/darp6".to_string())
     }
 
+    fn version(&self, _board: BoardId) -> Result<String, String> {
+        Err("Unimplemented".to_string())
+    }
+
     fn keymap_get(
         &self,
         _board: BoardId,

--- a/backend/src/daemon/server.rs
+++ b/backend/src/daemon/server.rs
@@ -129,6 +129,15 @@ impl<R: Read + Send + 'static, W: Write + Send + 'static> Daemon for DaemonServe
         Ok(board.to_string())
     }
 
+    fn version(&self, board: BoardId) -> Result<String, String> {
+        let mut ec = self.board(board)?;
+        let data_size = unsafe { ec.access().data_size() };
+        let mut data = vec![0; data_size];
+        let len = unsafe { ec.version(&mut data).map_err(err_str)? };
+        let version = str::from_utf8(&data[..len]).map_err(err_str)?;
+        Ok(version.to_string())
+    }
+
     fn keymap_get(&self, board: BoardId, layer: u8, output: u8, input: u8) -> Result<u16, String> {
         let mut ec = self.board(board)?;
         unsafe { ec.keymap_get(layer, output, input).map_err(err_str) }

--- a/i18n/en/system76_keyboard_configurator.ftl
+++ b/i18n/en/system76_keyboard_configurator.ftl
@@ -26,6 +26,8 @@ error-set-layer-mode = Failed to set layer mode
 error-unsupported-keymap = Unsupported keymap file
 error-unsupported-keymap-desc = Keymap file appears to be from newer Configurator version.
 
+firmware-version = Firmware version {$version} does not support keymap configuration.
+
 keyboard-brightness = Brightness:
 keyboard-color = Color:
 

--- a/src/main_window.rs
+++ b/src/main_window.rs
@@ -289,7 +289,7 @@ impl MainWindow {
         let app: ConfiguratorApp = self.get_application().unwrap().downcast().unwrap();
 
         let keyboard = cascade! {
-            Keyboard::new(board, app.debug_layers(), app.launch_test());
+            Keyboard::new(board.clone(), app.debug_layers(), app.launch_test());
             ..set_halign(gtk::Align::Center);
             ..show_all();
         };
@@ -329,6 +329,19 @@ impl MainWindow {
             ..show_all();
         };
         self.inner().keyboard_box.add(&row);
+
+        if !board.has_keymap() {
+            button.hide();
+            let label = cascade! {
+                gtk::Label::new(Some(&fl!("firmware-version", version = board.version())));
+                ..set_attributes(Some(&cascade! {
+                    pango::AttrList::new();
+                    ..insert(pango::Attribute::new_foreground(65535, 0, 0));
+                }));
+                ..show();
+            };
+            keyboard_box.add(&label);
+        }
 
         self.inner().stack.add(&keyboard);
         self.inner().keyboards.borrow_mut().push((keyboard, row));


### PR DESCRIPTION
Systems without Open EC firmware won't be detected at all, and this doesn't change that.

It looks like this (modifying `keymap_get` to fail even through the firmware I'm running supports it):

![Screenshot from 2021-06-11 13-49-39](https://user-images.githubusercontent.com/2263150/121747217-eaaf8a80-cabb-11eb-8626-7bc29daf8cd7.png)