### PR TITLE
improv: Disable overlay scrolling so scrollbar is only visible

### DIFF
--- a/src/main_window.rs
+++ b/src/main_window.rs
@@ -162,6 +162,7 @@ impl ObjectImpl for MainWindowInner {
                 ..add(&cascade! {
                     gtk::ScrolledWindow::new::<gtk::Adjustment, gtk::Adjustment>(None, None);
                     ..set_property_hscrollbar_policy(gtk::PolicyType::Never);
+                    ..set_overlay_scrolling(false);
                     ..add(&stack);
                 });
             });


### PR DESCRIPTION
Fixes https://github.com/pop-os/keyboard-configurator/issues/65.

This applies the change on every OS. Alternately it could be Windows/macOS specific.