### PR TITLE
Doc/fix links

### DIFF
--- a/backend/src/layout/physical_layout.rs
+++ b/backend/src/layout/physical_layout.rs
@@ -1,5 +1,5 @@
-/// Serde based deserialization for physical.json
-/// From http://www.keyboard-layout-editor.com
+//! Serde based deserialization for physical.json
+//! From <http://www.keyboard-layout-editor.com>
 use serde::Deserialize;
 use std::char;
 


### PR DESCRIPTION
- use 'enclosing scope' doc comments
- use URL link syntax

yes, i know these docs aren't currently exposed, but they might as well still be correct (or they could be changed to non-doc comments?)