### PR TITLE
WIP: Mod-Tap support with QMK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,6 +1583,7 @@ dependencies = [
 name = "system76-keyboard-configurator-backend"
 version = "0.1.0"
 dependencies = [
+ "cascade",
  "futures",
  "futures-timer",
  "glib",
@@ -1594,6 +1595,7 @@ dependencies = [
  "once_cell",
  "ordered-float",
  "palette",
+ "regex",
  "rust-embed",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,6 +1571,7 @@ dependencies = [
  "once_cell",
  "pango",
  "pangocairo",
+ "regex",
  "rust-embed",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ libc = "0.2"
 once_cell = "1.4"
 pango = { git = "https://github.com/pop-os/gtk-rs" }
 pangocairo = { git = "https://github.com/pop-os/gtk-rs" }
+regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4.0"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -6,6 +6,7 @@ license = "GPL-3.0-or-later"
 edition = "2018"
 
 [dependencies]
+cascade = "1"
 futures = "0.3.13"
 futures-timer = "3.0.2"
 glib = { git = "https://github.com/pop-os/gtk-rs" }
@@ -13,6 +14,7 @@ hidapi = { version = "1.2", default-features = false, features = ["linux-static-
 once_cell = "1.4"
 ordered-float = { version = "2.0", features = ["serde"] }
 palette = "0.5"
+regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4.0"

--- a/backend/src/key.rs
+++ b/backend/src/key.rs
@@ -147,7 +147,7 @@ impl Key {
         let board = self.board();
         let scancode = self.scancodes.get(layer)?.get();
         let scancode_name = match board.layout().scancode_to_name(scancode) {
-            Some(some) => some.to_string(),
+            Some(some) => some,
             None => String::new(),
         };
         Some((scancode, scancode_name))

--- a/backend/src/layout/meta.rs
+++ b/backend/src/layout/meta.rs
@@ -20,6 +20,9 @@ pub struct Meta {
     pub has_brightness: bool,
     /// Has LED with color (i.e. not monochrome)
     pub has_color: bool,
+    /// Supports mod-tap bindings (assumes QMK mod-tap encoding)
+    #[serde(default)]
+    pub has_mod_tap: bool,
     /// Number or layers; e.g. 2 where layer 2 is used when `Fn` is held
     #[serde(default = "num_layers_default")]
     pub num_layers: u8,

--- a/backend/src/layout/mod.rs
+++ b/backend/src/layout/mod.rs
@@ -1,11 +1,31 @@
+use cascade::cascade;
+use regex::Regex;
 use std::{collections::HashMap, fs, path::Path};
 
 mod meta;
+use once_cell::sync::Lazy;
 mod physical_layout;
 pub use self::meta::Meta;
 pub(crate) use physical_layout::{PhysicalLayout, PhysicalLayoutKey};
 
 use crate::KeyMap;
+
+const QK_MOD_TAP: u16 = 0x6000;
+const QK_MOD_TAP_MAX: u16 = 0x7FFF;
+
+pub static MOD_TAP_MODS: Lazy<HashMap<&str, u16>> = Lazy::new(|| {
+    cascade! {
+        HashMap::new();
+        ..insert("LEFT_CTRL", 0x01);
+        ..insert("LEFT_SHIFT", 0x02);
+        ..insert("LEFT_ALT", 0x04);
+        ..insert("LEFT_SUPER", 0x08);
+        ..insert("RIGHT_CTRL", 0x11);
+        ..insert("RIGHT_SHIFT", 0x12);
+        ..insert("RIGHT_ALT", 0x14);
+        ..insert("RIGHT_SUPER", 0x18);
+    }
+});
 
 pub struct Layout {
     /// Metadata for keyboard
@@ -123,13 +143,29 @@ impl Layout {
     }
 
     /// Get the scancode number corresponding to a name
-    pub fn scancode_to_name(&self, scancode: u16) -> Option<&str> {
-        self.scancode_names.get(&scancode).map(String::as_str)
+    pub fn scancode_to_name(&self, scancode: u16) -> Option<String> {
+        if scancode >= QK_MOD_TAP && scancode <= QK_MOD_TAP_MAX {
+            let mod_ = (scancode >> 8) & 0x1f;
+            let kc = scancode & 0xff;
+            let mod_name = MOD_TAP_MODS.iter().find(|(_, v)| **v == mod_)?.0;
+            let kc_name = self.scancode_names.get(&kc)?;
+            Some(format!("MT({}, {})", mod_name, kc_name))
+        } else {
+            self.scancode_names.get(&scancode).cloned()
+        }
     }
 
     /// Get the name corresponding to a scancode number
     pub fn scancode_from_name(&self, name: &str) -> Option<u16> {
-        self.keymap.get(name).copied()
+        // Check if mod-tap
+        let mt_re = Regex::new("MT\\(([^()]+), ([^()]+)\\)").unwrap();
+        if let Some(captures) = mt_re.captures(name) {
+            let mod_ = *MOD_TAP_MODS.get(&captures.get(1).unwrap().as_str())?;
+            let kc = *self.keymap.get(captures.get(2).unwrap().as_str())?;
+            Some(QK_MOD_TAP | ((mod_ & 0x1f) << 8) | (kc & 0xff))
+        } else {
+            self.keymap.get(name).copied()
+        }
     }
 }
 

--- a/layouts/system76/launch_1/meta.json
+++ b/layouts/system76/launch_1/meta.json
@@ -5,6 +5,7 @@
   "num_layers": 4,
   "has_brightness": true,
   "has_color": true,
+  "has_mod_tap": true,
   "pressed_color": "#202020",
   "keyboard": "system76/launch_1"
 }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -263,7 +263,7 @@ impl Keyboard {
         }
     }
 
-    fn layout(&self) -> &Layout {
+    pub fn layout(&self) -> &Layout {
         &self.inner().board.layout()
     }
 

--- a/src/picker/mod.rs
+++ b/src/picker/mod.rs
@@ -1,36 +1,20 @@
 use cascade::cascade;
-use futures::{prelude::*, stream::FuturesUnordered};
-use glib::clone;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use once_cell::sync::Lazy;
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+use std::collections::HashMap;
 
 use crate::Keyboard;
 use backend::DerefCell;
 
 mod picker_group;
+mod picker_group_box;
 mod picker_json;
 mod picker_key;
 
-use picker_group::PickerGroup;
+use picker_group_box::PickerGroupBox;
 use picker_json::picker_json;
 use picker_key::PickerKey;
-
-const DEFAULT_COLS: usize = 3;
-const HSPACING: i32 = 64;
-const VSPACING: i32 = 32;
-const PICKER_CSS: &str = r#"
-button {
-    margin: 0;
-    padding: 0;
-}
-
-.selected {
-    border-color: #fbb86c;
-    border-width: 4px;
-}
-"#;
 
 pub static SCANCODE_LABELS: Lazy<HashMap<String, String>> = Lazy::new(|| {
     let mut labels = HashMap::new();
@@ -44,16 +28,13 @@ pub static SCANCODE_LABELS: Lazy<HashMap<String, String>> = Lazy::new(|| {
 
 #[derive(Default)]
 pub struct PickerInner {
-    groups: DerefCell<Vec<PickerGroup>>,
-    keys: DerefCell<HashMap<String, Rc<PickerKey>>>,
-    keyboard: RefCell<Option<Keyboard>>,
-    selected: RefCell<Vec<String>>,
+    group_box: DerefCell<PickerGroupBox>,
 }
 
 #[glib::object_subclass]
 impl ObjectSubclass for PickerInner {
     const NAME: &'static str = "S76KeyboardPicker";
-    type ParentType = gtk::Container;
+    type ParentType = gtk::Box;
     type Type = Picker;
 }
 
@@ -61,170 +42,27 @@ impl ObjectImpl for PickerInner {
     fn constructed(&self, picker: &Picker) {
         self.parent_constructed(picker);
 
-        let style_provider = cascade! {
-            gtk::CssProvider::new();
-            ..load_from_data(&PICKER_CSS.as_bytes()).expect("Failed to parse css");
-        };
-
-        let mut groups = Vec::new();
-        let mut keys = HashMap::new();
-
-        for json_group in picker_json() {
-            let mut group = PickerGroup::new(json_group.label, json_group.cols);
-
-            for json_key in json_group.keys {
-                let key = PickerKey::new(
-                    json_key.keysym.clone(),
-                    json_key.label,
-                    json_group.width,
-                    &style_provider,
-                );
-
-                group.add_key(key.clone());
-                keys.insert(json_key.keysym, key);
-            }
-
-            groups.push(group);
-        }
-
-        for group in &groups {
-            group.vbox.show();
-            group.vbox.set_parent(picker);
-        }
-
-        self.keys.set(keys);
-        self.groups.set(groups);
+        let group_box = PickerGroupBox::new();
 
         cascade! {
             picker;
-            ..connect_signals();
+            ..add(&group_box);
             ..show_all();
         };
+
+        self.group_box.set(group_box);
     }
 }
 
-impl WidgetImpl for PickerInner {
-    fn get_request_mode(&self, _widget: &Self::Type) -> gtk::SizeRequestMode {
-        gtk::SizeRequestMode::HeightForWidth
-    }
+impl BoxImpl for PickerInner {}
 
-    fn get_preferred_width(&self, _widget: &Self::Type) -> (i32, i32) {
-        let minimum_width = self
-            .groups
-            .iter()
-            .map(|x| x.vbox.get_preferred_width().1)
-            .max()
-            .unwrap();
-        let natural_width = self
-            .groups
-            .chunks(3)
-            .map(|row| {
-                row.iter()
-                    .map(|x| x.vbox.get_preferred_width().1)
-                    .sum::<i32>()
-            })
-            .max()
-            .unwrap()
-            + 2 * HSPACING;
-        (minimum_width, natural_width)
-    }
+impl WidgetImpl for PickerInner {}
 
-    fn get_preferred_height_for_width(&self, widget: &Self::Type, width: i32) -> (i32, i32) {
-        let rows = widget.rows_for_width(width);
-        let height = rows
-            .iter()
-            .map(|row| {
-                row.iter()
-                    .map(|x| x.vbox.get_preferred_height().1)
-                    .max()
-                    .unwrap()
-            })
-            .sum::<i32>()
-            + (rows.len() as i32 - 1) * VSPACING;
-
-        (height, height)
-    }
-
-    fn size_allocate(&self, obj: &Self::Type, allocation: &gtk::Allocation) {
-        self.parent_size_allocate(obj, allocation);
-
-        let rows = obj.rows_for_width(allocation.width);
-
-        let total_width = rows
-            .iter()
-            .map(|row| {
-                row.iter()
-                    .map(|x| x.vbox.get_preferred_width().1)
-                    .sum::<i32>()
-                    + (row.len() as i32 - 1) * HSPACING
-            })
-            .max()
-            .unwrap();
-
-        let mut y = 0;
-        for row in rows {
-            let mut x = (allocation.width - total_width) / 2;
-            for group in row {
-                let height = group.vbox.get_preferred_height().1;
-                let width = group.vbox.get_preferred_width().1;
-                group.vbox.size_allocate(&gtk::Allocation {
-                    x,
-                    y,
-                    width,
-                    height,
-                });
-                x += width + HSPACING;
-            }
-            y += row
-                .iter()
-                .map(|x| x.vbox.get_preferred_height().1)
-                .max()
-                .unwrap()
-                + VSPACING;
-        }
-    }
-
-    fn realize(&self, widget: &Self::Type) {
-        let allocation = widget.get_allocation();
-        widget.set_realized(true);
-
-        let attrs = gdk::WindowAttr {
-            x: Some(allocation.x),
-            y: Some(allocation.y),
-            width: allocation.width,
-            height: allocation.height,
-            window_type: gdk::WindowType::Child,
-            event_mask: widget.get_events(),
-            wclass: gdk::WindowWindowClass::InputOutput,
-            ..Default::default()
-        };
-
-        let window = gdk::Window::new(widget.get_parent_window().as_ref(), &attrs);
-        widget.register_window(&window);
-        widget.set_window(&window);
-    }
-}
-
-impl ContainerImpl for PickerInner {
-    fn forall(
-        &self,
-        _obj: &Self::Type,
-        _include_internals: bool,
-        cb: &gtk::subclass::container::Callback,
-    ) {
-        for group in self.groups.iter() {
-            cb.call(group.vbox.upcast_ref());
-        }
-    }
-
-    fn remove(&self, _obj: &Self::Type, child: &gtk::Widget) {
-        child.unparent();
-    }
-}
+impl ContainerImpl for PickerInner {}
 
 glib::wrapper! {
     pub struct Picker(ObjectSubclass<PickerInner>)
-        @extends gtk::Container, gtk::Widget, @implements gtk::Orientable;
+        @extends gtk::Box, gtk::Container, gtk::Widget, @implements gtk::Orientable;
 }
 
 impl Picker {
@@ -236,101 +74,16 @@ impl Picker {
         PickerInner::from_instance(self)
     }
 
-    fn connect_signals(&self) {
-        let picker = self;
-        for group in self.inner().groups.iter() {
-            for key in group.iter_keys() {
-                let button = &key.gtk;
-                let name = key.name.to_string();
-                button.connect_clicked(clone!(@weak picker => @default-panic, move |_| {
-                    let kb = match picker.inner().keyboard.borrow().clone() {
-                        Some(kb) => kb,
-                        None => {
-                            return;
-                        }
-                    };
-                    let layer = kb.layer();
-
-                    info!("Clicked {} layer {:?}", name, layer);
-                    if let Some(layer) = layer {
-                        let futures = FuturesUnordered::new();
-                        for i in kb.selected().iter() {
-                            let i = *i;
-                            futures.push(clone!(@strong kb, @strong name => async move {
-                                kb.keymap_set(i, layer, &name).await;
-                            }));
-                        }
-                        glib::MainContext::default().spawn_local(async {futures.collect::<()>().await});
-                    }
-                }));
-            }
-        }
-    }
-
-    fn get_button(&self, scancode_name: &str) -> Option<&gtk::Button> {
-        self.inner().keys.get(scancode_name).map(|k| &k.gtk)
-    }
-
     pub(crate) fn set_keyboard(&self, keyboard: Option<Keyboard>) {
-        if let Some(old_kb) = &*self.inner().keyboard.borrow() {
-            old_kb.set_picker(None);
-        }
+        self.inner().group_box.set_keyboard(keyboard.clone());
+
         if let Some(kb) = &keyboard {
-            for group in self.inner().groups.iter() {
-                for key in group.iter_keys() {
-                    // Check that scancode is available for the keyboard
-                    let visible = kb.has_scancode(&key.name);
-                    key.gtk.set_visible(visible);
-                }
-            }
             kb.set_picker(Some(&self));
         }
-        *self.inner().keyboard.borrow_mut() = keyboard;
     }
 
     pub(crate) fn set_selected(&self, scancode_names: Vec<String>) {
-        let mut selected = self.inner().selected.borrow_mut();
-
-        for i in selected.iter() {
-            if let Some(button) = self.get_button(i) {
-                button.get_style_context().remove_class("selected");
-            }
-        }
-
-        *selected = scancode_names;
-
-        for i in selected.iter() {
-            if let Some(button) = self.get_button(i) {
-                button.get_style_context().add_class("selected");
-            }
-        }
-    }
-
-    fn rows_for_width(&self, container_width: i32) -> Vec<&[PickerGroup]> {
-        let mut rows = Vec::new();
-        let groups = &*self.inner().groups;
-
-        let mut row_start = 0;
-        let mut row_width = 0;
-        for (i, group) in groups.iter().enumerate() {
-            let width = group.vbox.get_preferred_width().1;
-
-            row_width += width;
-            if i != 0 {
-                row_width += HSPACING;
-            }
-            if i - row_start >= DEFAULT_COLS || row_width > container_width {
-                rows.push(&groups[row_start..i]);
-                row_start = i;
-                row_width = width;
-            }
-        }
-
-        if !groups[row_start..].is_empty() {
-            rows.push(&groups[row_start..]);
-        }
-
-        rows
+        self.inner().group_box.set_selected(scancode_names);
     }
 }
 

--- a/src/picker/mod.rs
+++ b/src/picker/mod.rs
@@ -4,7 +4,11 @@ use glib::clone;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use once_cell::sync::Lazy;
-use std::{cell::RefCell, collections::HashMap};
+use regex::Regex;
+use std::{
+    cell::{Cell, RefCell},
+    collections::HashMap,
+};
 
 use crate::Keyboard;
 use backend::DerefCell;
@@ -28,10 +32,23 @@ pub static SCANCODE_LABELS: Lazy<HashMap<String, String>> = Lazy::new(|| {
     labels
 });
 
+fn parse_mod_tap(name: &str) -> Option<(&str, &str)> {
+    let mt_re = Regex::new("MT\\(([^()]+), ([^()]+)\\)").unwrap();
+    mt_re.captures(name).map(|captures| {
+        let mod_name = captures.get(1).unwrap().as_str();
+        let kc_name = captures.get(2).unwrap().as_str();
+        (mod_name, kc_name)
+    })
+}
+
 #[derive(Default)]
 pub struct PickerInner {
     group_box: DerefCell<PickerGroupBox>,
     keyboard: RefCell<Option<Keyboard>>,
+    mod_tap_box: DerefCell<gtk::Box>,
+    mod_tap_check: DerefCell<gtk::CheckButton>,
+    mod_tap_mods: DerefCell<gtk::ComboBoxText>,
+    mod_tap_signal_blocked: Cell<bool>,
 }
 
 #[glib::object_subclass]
@@ -52,13 +69,50 @@ impl ObjectImpl for PickerInner {
             }));
         };
 
+        let mod_tap_mods = cascade! {
+            gtk::ComboBoxText::new();
+            ..append(Some("LEFT_CTRL"), "Left Ctrl");
+            ..append(Some("LEFT_SHIFT"), "Left Shift");
+            ..append(Some("LEFT_ALT"), "Left Alt");
+            ..append(Some("LEFT_SUPER"), "Left Super");
+            ..append(Some("RIGHT_CTRL"), "Right Ctrl");
+            ..append(Some("RIGHT_SHIFT"), "Right Shift");
+            ..append(Some("RIGHT_ALT"), "Right Alt");
+            ..append(Some("RIGHT_SUPER"), "Right Super");
+            ..set_active_id(Some("LEFT_CTRL"));
+            ..connect_property_active_id_notify(clone!(@weak picker => move |_| {
+                picker.mod_tap_updated();
+            }));
+        };
+
+        let mod_tap_check = cascade! {
+            gtk::CheckButton::with_label("Mod-Tap");
+            ..bind_property("active", &mod_tap_mods, "sensitive").flags(glib::BindingFlags::SYNC_CREATE).build();
+            ..connect_toggled(clone!(@weak picker => move |_| {
+                picker.update_key_visibility();
+                picker.mod_tap_updated();
+            }));
+        };
+
+        let mod_tap_box = cascade! {
+            gtk::Box::new(gtk::Orientation::Horizontal, 8);
+            ..add(&mod_tap_check);
+            ..add(&mod_tap_mods);
+        };
+
         cascade! {
             picker;
+            ..set_spacing(18);
+            ..set_orientation(gtk::Orientation::Vertical);
             ..add(&group_box);
+            ..add(&mod_tap_box);
             ..show_all();
         };
 
         self.group_box.set(group_box);
+        self.mod_tap_box.set(mod_tap_box);
+        self.mod_tap_check.set(mod_tap_check);
+        self.mod_tap_mods.set(mod_tap_mods);
     }
 }
 
@@ -82,45 +136,130 @@ impl Picker {
         PickerInner::from_instance(self)
     }
 
+    fn update_key_visibility(&self) {
+        let kb = match self.keyboard() {
+            Some(kb) => kb,
+            None => return,
+        };
+        let is_mod_tap =
+            self.inner().mod_tap_box.get_visible() && self.inner().mod_tap_check.get_active();
+        self.inner().group_box.set_key_visibility(|name| {
+            // Check that scancode is available for the keyboard
+            let visible = kb.has_scancode(name);
+            let sensitive = !is_mod_tap || kb.layout().scancode_from_name(name).unwrap_or(0) < 256;
+            (visible, sensitive)
+        });
+    }
+
     pub(crate) fn set_keyboard(&self, keyboard: Option<Keyboard>) {
         if let Some(old_kb) = &*self.inner().keyboard.borrow() {
             old_kb.set_picker(None);
         }
 
         if let Some(kb) = &keyboard {
-            // Check that scancode is available for the keyboard
-            self.inner().group_box.set_key_visibility(|name| {
-                let visible = kb.has_scancode(name);
-                let sensitive = true;
-                (visible, sensitive)
-            });
             kb.set_picker(Some(&self));
+
+            self.inner()
+                .mod_tap_box
+                .set_visible(kb.layout().meta.has_mod_tap);
         }
 
         *self.inner().keyboard.borrow_mut() = keyboard;
+        self.update_key_visibility();
     }
 
-    pub(crate) fn set_selected(&self, scancode_names: Vec<String>) {
+    pub(crate) fn set_selected(&self, mut scancode_names: Vec<String>) {
+        self.inner().mod_tap_signal_blocked.set(true);
+
+        self.inner().mod_tap_box.set_sensitive(false);
+        self.inner().mod_tap_check.set_active(false);
+        self.inner().mod_tap_mods.set_active_id(Some("LEFT_CTRL"));
+
+        if scancode_names.len() == 1 {
+            self.inner().mod_tap_box.set_sensitive(true);
+            if let Some((mod_name, _)) = parse_mod_tap(&scancode_names[0]) {
+                self.inner().mod_tap_check.set_active(true);
+                self.inner().mod_tap_mods.set_active_id(Some(mod_name));
+            }
+        }
+
+        self.inner().mod_tap_signal_blocked.set(false);
+
+        for i in scancode_names.iter_mut() {
+            if let Some((_, kc_name)) = parse_mod_tap(&i) {
+                *i = kc_name.to_string();
+            }
+        }
+
         self.inner().group_box.set_selected(scancode_names);
     }
 
-    fn key_pressed(&self, name: String) {
-        let kb = match self.inner().keyboard.borrow().clone() {
+    fn mod_(&self) -> Option<String> {
+        if self.inner().mod_tap_box.get_visible() && self.inner().mod_tap_check.get_active() {
+            Some(self.inner().mod_tap_mods.get_active_id()?.into())
+        } else {
+            None
+        }
+    }
+
+    fn keyboard(&self) -> Option<Keyboard> {
+        self.inner().keyboard.borrow().clone()
+    }
+
+    fn key_pressed(&self, mut name: String) {
+        let kb = match self.keyboard() {
             Some(kb) => kb,
-            None => {
-                return;
-            }
+            None => return,
         };
         let layer = kb.layer();
+
+        if let Some(mod_) = self.mod_() {
+            name = format!("MT({}, {})", mod_, name);
+        }
 
         info!("Clicked {} layer {:?}", name, layer);
         if let Some(layer) = layer {
             let futures = FuturesUnordered::new();
-            for i in kb.selected().iter() {
-                let i = *i;
+            for i in kb.selected().iter().copied() {
                 futures.push(clone!(@strong kb, @strong name => async move {
                     kb.keymap_set(i, layer, &name).await;
                 }));
+            }
+            glib::MainContext::default().spawn_local(async { futures.collect::<()>().await });
+        }
+    }
+
+    fn mod_tap_updated(&self) {
+        if self.inner().mod_tap_signal_blocked.get() {
+            return;
+        }
+
+        let kb = match self.keyboard() {
+            Some(kb) => kb,
+            None => return,
+        };
+        let layer = kb.layer();
+
+        if let Some(layer) = layer {
+            let futures = FuturesUnordered::new();
+            for i in kb.selected().iter().copied() {
+                if let Some((_, scancode)) = &kb.board().keys()[i].get_scancode(layer) {
+                    let kc_name = if let Some((_, kc_name)) = parse_mod_tap(scancode) {
+                        kc_name
+                    } else {
+                        scancode
+                    };
+
+                    let name = if let Some(mod_name) = self.mod_() {
+                        format!("MT({}, {})", mod_name, kc_name)
+                    } else {
+                        kc_name.to_string()
+                    };
+
+                    futures.push(clone!(@strong kb, @strong name => async move {
+                        kb.keymap_set(i, layer, &name).await;
+                    }));
+                }
             }
             glib::MainContext::default().spawn_local(async { futures.collect::<()>().await });
         }

--- a/src/picker/picker_group_box.rs
+++ b/src/picker/picker_group_box.rs
@@ -1,0 +1,319 @@
+use cascade::cascade;
+use futures::{prelude::*, stream::FuturesUnordered};
+use glib::clone;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
+
+use crate::Keyboard;
+use backend::DerefCell;
+
+use super::{picker_group::PickerGroup, picker_json::picker_json, picker_key::PickerKey};
+
+const DEFAULT_COLS: usize = 3;
+const HSPACING: i32 = 64;
+const VSPACING: i32 = 32;
+const PICKER_CSS: &str = r#"
+button {
+    margin: 0;
+    padding: 0;
+}
+
+.selected {
+    border-color: #fbb86c;
+    border-width: 4px;
+}
+"#;
+
+#[derive(Default)]
+pub struct PickerGroupBoxInner {
+    groups: DerefCell<Vec<PickerGroup>>,
+    keys: DerefCell<HashMap<String, Rc<PickerKey>>>,
+    keyboard: RefCell<Option<Keyboard>>,
+    selected: RefCell<Vec<String>>,
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for PickerGroupBoxInner {
+    const NAME: &'static str = "S76KeyboardPickerGroupBox";
+    type ParentType = gtk::Container;
+    type Type = PickerGroupBox;
+}
+
+impl ObjectImpl for PickerGroupBoxInner {
+    fn constructed(&self, widget: &PickerGroupBox) {
+        self.parent_constructed(widget);
+
+        let style_provider = cascade! {
+            gtk::CssProvider::new();
+            ..load_from_data(&PICKER_CSS.as_bytes()).expect("Failed to parse css");
+        };
+
+        let mut groups = Vec::new();
+        let mut keys = HashMap::new();
+
+        for json_group in picker_json() {
+            let mut group = PickerGroup::new(json_group.label, json_group.cols);
+
+            for json_key in json_group.keys {
+                let key = PickerKey::new(
+                    json_key.keysym.clone(),
+                    json_key.label,
+                    json_group.width,
+                    &style_provider,
+                );
+
+                group.add_key(key.clone());
+                keys.insert(json_key.keysym, key);
+            }
+
+            groups.push(group);
+        }
+
+        for group in &groups {
+            group.vbox.show();
+            group.vbox.set_parent(widget);
+        }
+
+        self.keys.set(keys);
+        self.groups.set(groups);
+
+        cascade! {
+            widget;
+            ..connect_signals();
+            ..show_all();
+        };
+    }
+}
+
+impl WidgetImpl for PickerGroupBoxInner {
+    fn get_request_mode(&self, _widget: &Self::Type) -> gtk::SizeRequestMode {
+        gtk::SizeRequestMode::HeightForWidth
+    }
+
+    fn get_preferred_width(&self, _widget: &Self::Type) -> (i32, i32) {
+        let minimum_width = self
+            .groups
+            .iter()
+            .map(|x| x.vbox.get_preferred_width().1)
+            .max()
+            .unwrap();
+        let natural_width = self
+            .groups
+            .chunks(3)
+            .map(|row| {
+                row.iter()
+                    .map(|x| x.vbox.get_preferred_width().1)
+                    .sum::<i32>()
+            })
+            .max()
+            .unwrap()
+            + 2 * HSPACING;
+        (minimum_width, natural_width)
+    }
+
+    fn get_preferred_height_for_width(&self, widget: &Self::Type, width: i32) -> (i32, i32) {
+        let rows = widget.rows_for_width(width);
+        let height = rows
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .map(|x| x.vbox.get_preferred_height().1)
+                    .max()
+                    .unwrap()
+            })
+            .sum::<i32>()
+            + (rows.len() as i32 - 1) * VSPACING;
+
+        (height, height)
+    }
+
+    fn size_allocate(&self, obj: &Self::Type, allocation: &gtk::Allocation) {
+        self.parent_size_allocate(obj, allocation);
+
+        let rows = obj.rows_for_width(allocation.width);
+
+        let total_width = rows
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .map(|x| x.vbox.get_preferred_width().1)
+                    .sum::<i32>()
+                    + (row.len() as i32 - 1) * HSPACING
+            })
+            .max()
+            .unwrap();
+
+        let mut y = 0;
+        for row in rows {
+            let mut x = (allocation.width - total_width) / 2;
+            for group in row {
+                let height = group.vbox.get_preferred_height().1;
+                let width = group.vbox.get_preferred_width().1;
+                group.vbox.size_allocate(&gtk::Allocation {
+                    x,
+                    y,
+                    width,
+                    height,
+                });
+                x += width + HSPACING;
+            }
+            y += row
+                .iter()
+                .map(|x| x.vbox.get_preferred_height().1)
+                .max()
+                .unwrap()
+                + VSPACING;
+        }
+    }
+
+    fn realize(&self, widget: &Self::Type) {
+        let allocation = widget.get_allocation();
+        widget.set_realized(true);
+
+        let attrs = gdk::WindowAttr {
+            x: Some(allocation.x),
+            y: Some(allocation.y),
+            width: allocation.width,
+            height: allocation.height,
+            window_type: gdk::WindowType::Child,
+            event_mask: widget.get_events(),
+            wclass: gdk::WindowWindowClass::InputOutput,
+            ..Default::default()
+        };
+
+        let window = gdk::Window::new(widget.get_parent_window().as_ref(), &attrs);
+        widget.register_window(&window);
+        widget.set_window(&window);
+    }
+}
+
+impl ContainerImpl for PickerGroupBoxInner {
+    fn forall(
+        &self,
+        _obj: &Self::Type,
+        _include_internals: bool,
+        cb: &gtk::subclass::container::Callback,
+    ) {
+        for group in self.groups.iter() {
+            cb.call(group.vbox.upcast_ref());
+        }
+    }
+
+    fn remove(&self, _obj: &Self::Type, child: &gtk::Widget) {
+        child.unparent();
+    }
+}
+
+glib::wrapper! {
+    pub struct PickerGroupBox(ObjectSubclass<PickerGroupBoxInner>)
+        @extends gtk::Container, gtk::Widget, @implements gtk::Orientable;
+}
+
+impl PickerGroupBox {
+    pub fn new() -> Self {
+        glib::Object::new(&[]).unwrap()
+    }
+
+    fn inner(&self) -> &PickerGroupBoxInner {
+        PickerGroupBoxInner::from_instance(self)
+    }
+
+    fn connect_signals(&self) {
+        let picker = self;
+        for group in self.inner().groups.iter() {
+            for key in group.iter_keys() {
+                let button = &key.gtk;
+                let name = key.name.to_string();
+                button.connect_clicked(clone!(@weak picker => @default-panic, move |_| {
+                    let kb = match picker.inner().keyboard.borrow().clone() {
+                        Some(kb) => kb,
+                        None => {
+                            return;
+                        }
+                    };
+                    let layer = kb.layer();
+
+                    info!("Clicked {} layer {:?}", name, layer);
+                    if let Some(layer) = layer {
+                        let futures = FuturesUnordered::new();
+                        for i in kb.selected().iter() {
+                            let i = *i;
+                            futures.push(clone!(@strong kb, @strong name => async move {
+                                kb.keymap_set(i, layer, &name).await;
+                            }));
+                        }
+                        glib::MainContext::default().spawn_local(async {futures.collect::<()>().await});
+                    }
+                }));
+            }
+        }
+    }
+
+    fn get_button(&self, scancode_name: &str) -> Option<&gtk::Button> {
+        self.inner().keys.get(scancode_name).map(|k| &k.gtk)
+    }
+
+    pub(crate) fn set_keyboard(&self, keyboard: Option<Keyboard>) {
+        if let Some(old_kb) = &*self.inner().keyboard.borrow() {
+            old_kb.set_picker(None);
+        }
+
+        if let Some(kb) = &keyboard {
+            for group in self.inner().groups.iter() {
+                for key in group.iter_keys() {
+                    // Check that scancode is available for the keyboard
+                    let visible = kb.has_scancode(&key.name);
+                    key.gtk.set_visible(visible);
+                }
+            }
+        }
+
+        *self.inner().keyboard.borrow_mut() = keyboard;
+    }
+
+    pub(crate) fn set_selected(&self, scancode_names: Vec<String>) {
+        let mut selected = self.inner().selected.borrow_mut();
+
+        for i in selected.iter() {
+            if let Some(button) = self.get_button(i) {
+                button.get_style_context().remove_class("selected");
+            }
+        }
+
+        *selected = scancode_names;
+
+        for i in selected.iter() {
+            if let Some(button) = self.get_button(i) {
+                button.get_style_context().add_class("selected");
+            }
+        }
+    }
+
+    fn rows_for_width(&self, container_width: i32) -> Vec<&[PickerGroup]> {
+        let mut rows = Vec::new();
+        let groups = &*self.inner().groups;
+
+        let mut row_start = 0;
+        let mut row_width = 0;
+        for (i, group) in groups.iter().enumerate() {
+            let width = group.vbox.get_preferred_width().1;
+
+            row_width += width;
+            if i != 0 {
+                row_width += HSPACING;
+            }
+            if i - row_start >= DEFAULT_COLS || row_width > container_width {
+                rows.push(&groups[row_start..i]);
+                row_start = i;
+                row_width = width;
+            }
+        }
+
+        if !groups[row_start..].is_empty() {
+            rows.push(&groups[row_start..]);
+        }
+
+        rows
+    }
+}


### PR DESCRIPTION
This should be working now, but the PR is a draft pending a better UI. Don't know if @maria-komarova or anyone else has ideas on it.

As implemented currently, it adds a check box and a dropdown at the bottom of the keycode picker. Not sure that's the best solution:

![Screenshot from 2021-07-23 13-37-47](https://user-images.githubusercontent.com/2263150/126838913-02f057c3-4a5b-4ca2-bdb0-5390ef88e407.png)

Currently it doesn't properly format the text for the mod-tap keycode when displaying it on the keyboard, instead just showing something like `MT(LEFT_CTRL, A)`. Not sure what could be displayed that would be short enough and clear...

![Screenshot from 2021-07-23 13-37-36](https://user-images.githubusercontent.com/2263150/126838925-6348162e-0032-4ccc-850c-5c52f91c09f1.png)

One strange limitation of mod-tap, as mentioned in QMK's documentation, is that it only works with keycodes up to 255, so some of them don't work with the feature. This branch thus sets the sensitivity of keys appropriately, as seen here. Not sure if there's anything that would make this clearer.

![Screenshot from 2021-07-23 13-38-32](https://user-images.githubusercontent.com/2263150/126838996-77c61d9d-a100-4bcb-bcd2-0f1326310ab2.png)

Resolves https://github.com/pop-os/keyboard-configurator/issues/64.