### PR TITLE
testing: Use `Keyboard::import_keymap`, and restore default layout

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -182,7 +182,7 @@ impl Keyboard {
 
         if launch_test {
             let testing = cascade! {
-                Testing::new(board.clone());
+                Testing::new(&board, &keyboard);
                 ..set_halign(gtk::Align::Center);
             };
             stack.add_titled(&testing, "testing", &fl!("stack-testing"));
@@ -456,7 +456,7 @@ impl Keyboard {
         }
     }
 
-    async fn reset(&self) {
+    pub async fn reset(&self) {
         self.import_keymap(self.layout().default.clone()).await;
     }
 


### PR DESCRIPTION
This resets the keymap to the default, instead of trying to restore what was previously set. This seems safer.

It also displays the indicator at the top of the window that the layout is being set like the "Reset Layout" and "Import Layout" buttons do, and makes some of the code simpler.