### PR TITLE
fix: Use `FlowBox` for picker group, and reflow as need

### DIFF
--- a/src/picker/mod.rs
+++ b/src/picker/mod.rs
@@ -89,11 +89,9 @@ impl Picker {
 
         if let Some(kb) = &keyboard {
             // Check that scancode is available for the keyboard
-            self.inner().group_box.set_key_visibility(|name| {
-                let visible = kb.has_scancode(name);
-                let sensitive = true;
-                (visible, sensitive)
-            });
+            self.inner()
+                .group_box
+                .set_key_visibility(|name| kb.has_scancode(name));
             kb.set_picker(Some(&self));
         }
 

--- a/src/picker/picker_group_box.rs
+++ b/src/picker/picker_group_box.rs
@@ -248,11 +248,13 @@ impl PickerGroupBox {
         self.inner().keys.get(scancode_name).map(|k| &k.gtk)
     }
 
-    pub(crate) fn set_key_visibility<F: Fn(&str) -> (bool, bool)>(&self, f: F) {
+    pub(crate) fn set_key_visibility<F: Fn(&str) -> bool>(&self, f: F) {
         for key in self.inner().keys.values() {
-            let (visible, sensitive) = f(&key.name);
-            key.gtk.set_visible(visible);
-            key.gtk.set_sensitive(sensitive);
+            key.gtk.set_visible(f(&key.name));
+        }
+
+        for group in self.inner().groups.iter() {
+            group.invalidate_filter();
         }
     }
 

--- a/src/picker/picker_json.rs
+++ b/src/picker/picker_json.rs
@@ -9,7 +9,7 @@ pub struct PickerJsonKey {
 #[derive(Deserialize)]
 pub struct PickerJsonGroup {
     pub label: String,
-    pub cols: i32,
+    pub cols: u32,
     pub width: i32,
     pub keys: Vec<PickerJsonKey>,
 }


### PR DESCRIPTION
This reflows children after hiding children when switching keyboards.

This fixes the behavior with `cols` not behaving as expected noticed in https://github.com/pop-os/keyboard-configurator/pull/97.