### PR TITLE
fix(testing): Use a 'no_input' mode instead of modifying keymap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "system76_ectool"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d8dd684c7c15fda72766bcd42d73c3152c7ace6e0c3f98e3e58f77cd0174a0"
+checksum = "5fa1f8f8e61d62f04c704268e040df5f37bd454af161c147bb2b491f68661ebe"
 dependencies = [
  "clap",
  "downcast-rs",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -25,7 +25,7 @@ i18n-embed-fl = "0.5.0"
 rust-embed = { version = "5.9.0", features = ["debug-embed"] }
 
 [dependencies.system76_ectool]
-version = "0.3.6"
+version = "0.3.8"
 features = ["hidapi", "std"]
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/backend/src/board.rs
+++ b/backend/src/board.rs
@@ -287,4 +287,10 @@ impl Board {
             layers,
         }
     }
+
+    pub async fn set_no_input(&self, no_input: bool) -> Result<(), String> {
+        self.thread_client()
+            .set_no_input(self.board(), no_input)
+            .await
+    }
 }

--- a/backend/src/daemon/daemon_thread.rs
+++ b/backend/src/daemon/daemon_thread.rs
@@ -58,6 +58,7 @@ enum SetEnum {
     LedSave(BoardId),
     MatrixGetRate(Item<(), Option<Duration>>),
     Refresh,
+    NoInput(BoardId, bool),
     Exit,
 }
 
@@ -239,6 +240,10 @@ impl ThreadClient {
         self.send_noresp(SetEnum::LedSave(board)).await
     }
 
+    pub async fn set_no_input(&self, board: BoardId, no_input: bool) -> Result<(), String> {
+        self.send_noresp(SetEnum::NoInput(board, no_input)).await
+    }
+
     pub fn close(&self) {
         let join_handle = match self.join_handle.lock().unwrap().take() {
             Some(join_handle) => join_handle,
@@ -361,6 +366,9 @@ impl Thread {
                 set.reply(Ok(()))
             }
             SetEnum::Refresh => set.reply(self.refresh()),
+            SetEnum::NoInput(board, no_input) => {
+                set.reply(self.daemon.set_no_input(board, no_input))
+            }
             SetEnum::Exit => return false,
         }
 

--- a/backend/src/daemon/dummy.rs
+++ b/backend/src/daemon/dummy.rs
@@ -171,6 +171,10 @@ impl Daemon for DaemonDummy {
         Ok(())
     }
 
+    fn set_no_input(&self, _board: BoardId, _no_input: bool) -> Result<(), String> {
+        Ok(())
+    }
+
     fn exit(&self) -> Result<(), String> {
         Ok(())
     }

--- a/backend/src/daemon/mod.rs
+++ b/backend/src/daemon/mod.rs
@@ -95,6 +95,7 @@ commands! {
     fn mode(&self, board: BoardId, layer: u8) -> Result<(u8, u8), String>;
     fn set_mode(&self, board: BoardId, layer: u8, mode: u8, speed: u8) -> Result<(), String>;
     fn led_save(&self, board: BoardId) -> Result<(), String>;
+    fn set_no_input(&self, board: BoardId, no_input: bool) -> Result<(), String>;
     fn exit(&self) -> Result<(), String>;
 }
 

--- a/backend/src/daemon/s76power.rs
+++ b/backend/src/daemon/s76power.rs
@@ -177,6 +177,10 @@ impl Daemon for DaemonS76Power {
         Ok(())
     }
 
+    fn set_no_input(&self, _board: BoardId, _no_input: bool) -> Result<(), String> {
+        Err("Unimplemented".to_string())
+    }
+
     fn exit(&self) -> Result<(), String> {
         Ok(())
     }

--- a/backend/src/daemon/server.rs
+++ b/backend/src/daemon/server.rs
@@ -374,6 +374,11 @@ impl<R: Read + Send + 'static, W: Write + Send + 'static> Daemon for DaemonServe
         Ok(())
     }
 
+    fn set_no_input(&self, board: BoardId, no_input: bool) -> Result<(), String> {
+        let mut ec = self.board(board)?;
+        unsafe { ec.set_no_input(no_input) }.map_err(err_str)
+    }
+
     fn exit(&self) -> Result<(), String> {
         self.running.set(false);
         Ok(())


### PR DESCRIPTION
Should address the concern in https://github.com/system76/launch/issues/53.

Still need to find a way to make the backend crate less redundant, but anyway, this should work.

Requires firmware built from https://github.com/system76/qmk_firmware/pull/20. This updates `ectool` to the branch in https://github.com/system76/ec/pull/259. That should be probably be merged and released before this PR, so the dependency here can use the released version.