### PR TITLE
feat: Menu option to Invert F Keys

### DIFF
--- a/backend/src/layout/meta.rs
+++ b/backend/src/layout/meta.rs
@@ -23,6 +23,9 @@ pub struct Meta {
     /// Supports mod-tap bindings (assumes QMK mod-tap encoding)
     #[serde(default)]
     pub has_mod_tap: bool,
+    #[serde(default)]
+    /// Disable "Invert F Keys" option
+    pub no_fn_f: bool,
     /// Number or layers; e.g. 2 where layer 2 is used when `Fn` is held
     #[serde(default = "num_layers_default")]
     pub num_layers: u8,

--- a/backend/src/layout/mod.rs
+++ b/backend/src/layout/mod.rs
@@ -167,6 +167,17 @@ impl Layout {
             self.keymap.get(name).copied()
         }
     }
+
+    pub fn f_keys(&self) -> impl Iterator<Item = &str> {
+        self.default.map.iter().filter_map(|(k, v)| {
+            if let Some(num) = v[0].strip_prefix('F') {
+                if num.parse::<u8>().is_ok() {
+                    return Some(k.as_str());
+                }
+            }
+            None
+        })
+    }
 }
 
 fn parse_keymap_json(keymap_json: &str) -> (HashMap<String, u16>, HashMap<u16, String>) {
@@ -278,6 +289,14 @@ mod tests {
                 "{}",
                 i
             );
+        }
+    }
+
+    #[test]
+    fn layout_has_f_keys() {
+        for i in layouts() {
+            let layout = Layout::from_board(i).unwrap();
+            assert_eq!(layout.f_keys().count(), 12);
         }
     }
 }

--- a/i18n/en/system76_keyboard_configurator.ftl
+++ b/i18n/en/system76_keyboard_configurator.ftl
@@ -46,6 +46,7 @@ layer-saturation = Layer Saturation:
 layout-export = Export Layout
 layout-import = Import Layout
 layout-reset = Reset Layout
+layout-invert-f-keys = Invert F Keys
 
 loading = Keyboard(s) detected. Loading...
 loading-keyboard = Loading keymap and LEDs for {$keyboard}

--- a/layouts/system76/launch_1/meta.json
+++ b/layouts/system76/launch_1/meta.json
@@ -6,6 +6,7 @@
   "has_brightness": true,
   "has_color": true,
   "has_mod_tap": true,
+  "no_fn_f": true,
   "pressed_color": "#202020",
   "keyboard": "system76/launch_1"
 }

--- a/src/main_window.rs
+++ b/src/main_window.rs
@@ -68,6 +68,7 @@ impl ObjectImpl for MainWindowInner {
                 ..append(Some(&fl!("layout-import")), Some("kbd.import"));
                 ..append(Some(&fl!("layout-export")), Some("kbd.export"));
                 ..append(Some(&fl!("layout-reset")), Some("kbd.reset"));
+                ..append(Some(&fl!("layout-invert-f-keys")), Some("kbd.invert-f-keys"));
             });
             ..append_section(None, &cascade! {
                 gio::Menu::new();


### PR DESCRIPTION
Implements https://github.com/pop-os/keyboard-configurator/issues/24.

Not sure if there's a better way to describe this, or any other way to improve it, but it seems appropriate to provide an easy way to do this. It is a common option provided by laptop firmware these days, and users have complained that it's overly complicated to change each key manually.

This has no impact on the default Launch layout since nothing is bound on layer 2 for the F keys. Not sure if that could be confusing or could be improved.