### PR TITLE
Remove useless `info!`

### DIFF
--- a/src/picker/mod.rs
+++ b/src/picker/mod.rs
@@ -113,7 +113,6 @@ impl Picker {
         };
         let layer = kb.layer();
 
-        info!("Clicked {} layer {:?}", name, layer);
         if let Some(layer) = layer {
             let futures = FuturesUnordered::new();
             for i in kb.selected().iter() {


### PR DESCRIPTION
There is no need to print this to the terminal every time a user clicks a modifier key.

Example:
Select a key, and the try to modify the key, the terminal output will be similar to
`[INFO ] Clicked F layer Some(3)`