### PR TITLE
More idiomatic translation of ES strings

### DIFF
--- a/i18n/es/system76_keyboard_configurator.ftl
+++ b/i18n/es/system76_keyboard_configurator.ftl
@@ -1,6 +1,6 @@
--name = Configurador del Teclado
+-name = Configurador del teclado
 
-app-about = Sobre {-name}
+app-about = Acerca de {-name}
 app-title = {-name} System76
 
 board-fake = {$model}, falso
@@ -20,15 +20,15 @@ error-key-led = Fallo a cambiar el LED de la tecla
 error-open-file = Fallo al abrir el archivo
 error-save-leds = Fallo al guardar LEDs
 error-set-keyboard-brightness = Fallo al cambiar el brillo
-error-set-keyboard-mode = Error al cambiar modo del teclado
+error-set-keyboard-mode = Fallo al cambiar modo del teclado
 error-set-keymap = Fallo al cambiar mapeo
 error-set-layer-brightness = Fallo al cambiar el brillo de la capa
-error-set-layer-color = Fallo al cambiar color de la capa
-error-set-layer-mode = Fallo al cambiar modo de capa
-error-unsupported-keymap = Archivo de mapeo insoportado
-error-unsupported-keymap-desc = Archivo de mapeo parece ser de una versión más reciente del Configurador.
+error-set-layer-color = Fallo al cambiar el color de la capa
+error-set-layer-mode = Fallo al cambiar el modo de capa
+error-unsupported-keymap = Archivo de mapeo no respaldado
+error-unsupported-keymap-desc = El archivo de mapeo parece ser de una versión más reciente del configurador.
 
-firmware-version = La versión de firmware {$version} no soporta configuración del mapeo de teclas.
+firmware-version = La versión de firmware {$version} no respalda la configuración del mapeo de teclas.
 
 keyboard-brightness = Brillo:
 keyboard-color = Color:
@@ -60,7 +60,7 @@ page-layer4 = Capa 4
 page-leds = LEDs
 page-logical = Lógica
 
-no-boards = No hay ningún teclado detectado
+no-boards = No se detecta ningún teclado
 no-boards-msg = Asegurate que tu teclado integrado tiene un Firmware
  System76 actualizado.
  Si estás usando un teclado externo, asegúrate que

--- a/i18n/es/system76_keyboard_configurator_backend.ftl
+++ b/i18n/es/system76_keyboard_configurator_backend.ftl
@@ -1,16 +1,16 @@
 mode-disabled = Desabilitado
-mode-solid-color = Color Solido por capa
-mode-per-key = Solido por tecla
+mode-solid-color = Color sólido por capa
+mode-per-key = Sólido por tecla
 mode-active-keys = Solo teclas enlazadas
 mode-cycle-all = Fondo cosmico
-mode-cycle-left-right = Escaneo horizontal
-mode-cycle-up-down = Escaneo vertical
-mode-cycle-out-in = Evento de horizonte
+mode-cycle-left-right = Barrido horizontal
+mode-cycle-up-down = Barrido vertical
+mode-cycle-out-in = Horizonte de sucesos
 mode-cycle-out-in-dual = Galaxias binarias
-mode-rainbow-moving-chevron = Tiempo espacial
-mode-cycle-pinwheel = Galaxia molinillo
+mode-rainbow-moving-chevron = Espacio-tiempo
+mode-cycle-pinwheel = Galaxia de molinillo
 mode-cycle-spiral = Galaxia espiral
-mode-raindrops = Elementos Elements
+mode-raindrops = Elementos
 mode-splash = Chapuzón
 mode-multisplash = Lluvia de meteoritos
 

--- a/i18n/es/system76_keyboard_configurator_widgets.ftl
+++ b/i18n/es/system76_keyboard_configurator_widgets.ftl
@@ -2,12 +2,12 @@ button-color = Color
 button-cancel = Cancelar
 button-save = Guardar
 
-choose-color = Escoger color
+choose-color = Escoger un color
 
 error-set-color = Fallo al aplicar color del teclado
 error-set-brightness = Fallo al aplicar brillo del teclado
 
 label-hue = Matíz
-label-saturation = Saturacion
+label-saturation = Saturación
 
 scale-brightness = Brillo


### PR DESCRIPTION
Some of the `es` strings in the configurator where non-standard to Spanish language software conventions, or contained typos. I fixed them with more idiomatic translations and spelling.