### PR TITLE
set default value for nelson test 3 to 100

### DIFF
--- a/src/testing.rs
+++ b/src/testing.rs
@@ -154,6 +154,8 @@ impl ObjectImpl for TestingInner {
 
         let num_runs_spin_2 = gtk::SpinButton::with_range(1.0, 1000.0, 1.0);
         let num_runs_spin_3 = gtk::SpinButton::with_range(1.0, 1000.0, 1.0);
+        num_runs_spin_3.set_value(100.0);
+
         let test_buttons = [
             gtk::Button::with_label(&fl!("button-test")),
             gtk::Button::with_label(&fl!("button-test")),


### PR DESCRIPTION
Requested by production. default value is 1, but nelson test 3 is always 100

![Screenshot from 2022-02-25 15-07-30](https://user-images.githubusercontent.com/58987761/155809684-d9f8b029-154b-449f-b172-47d90bbf3800.png)
.