### PR TITLE
Fix issue with scrolling behavior in some cases

### DIFF
--- a/src/keyboard_layer.rs
+++ b/src/keyboard_layer.rs
@@ -222,6 +222,11 @@ impl WidgetImpl for KeyboardLayerInner {
         (widget.narrow_width(), widget.wide_width())
     }
 
+    fn preferred_height(&self, widget: &Self::Type) -> (i32, i32) {
+        let height = widget.narrow_height();
+        (height, height)
+    }
+
     fn preferred_height_for_width(&self, widget: &Self::Type, width: i32) -> (i32, i32) {
         let height = if width < widget.wide_width() {
             widget.narrow_height()
@@ -229,6 +234,10 @@ impl WidgetImpl for KeyboardLayerInner {
             widget.wide_height()
         };
         (height, height)
+    }
+
+    fn preferred_width_for_height(&self, widget: &Self::Type, _width: i32) -> (i32, i32) {
+        self.preferred_width(widget)
     }
 }
 

--- a/src/main_window.rs
+++ b/src/main_window.rs
@@ -36,7 +36,7 @@ pub struct MainWindowInner {
     load_revealer: DerefCell<gtk::Revealer>,
     picker: DerefCell<Picker>,
     stack: DerefCell<gtk::Stack>,
-    keyboards: RefCell<Vec<(Keyboard, gtk::ListBoxRow)>>,
+    keyboards: RefCell<Vec<(Keyboard, gtk::Box)>>,
     board_loading: RefCell<Option<Loader>>,
     board_list_stack: DerefCell<gtk::Stack>,
 }
@@ -127,8 +127,6 @@ impl ObjectImpl for MainWindowInner {
         let keyboard_box = cascade! {
             gtk::Box::new(gtk::Orientation::Vertical, 0);
             ..set_halign(gtk::Align::Center);
-            ..connect_add(clone!(@weak board_list_stack => move |_, _| {
-            }));
         };
         board_list_stack.add_named(&keyboard_box, "keyboards");
 
@@ -320,18 +318,12 @@ impl MainWindow {
             KeyboardLayer::new(Page::Layer1, keyboard.board().clone());
             ..set_halign(gtk::Align::Center);
         };
-        let keyboard_box = cascade! {
+        let row = cascade! {
             gtk::Box::new(gtk::Orientation::Vertical, 12);
+            ..set_margin(12);
             ..add(&label);
             ..add(&keyboard_layer);
             ..add(&button);
-        };
-        let row = cascade! {
-            gtk::ListBoxRow::new();
-            ..set_activatable(false);
-            ..set_selectable(false);
-            ..add(&keyboard_box);
-            ..set_margin(12);
             ..show_all();
         };
         self.inner().keyboard_box.add(&row);
@@ -346,7 +338,7 @@ impl MainWindow {
                 }));
                 ..show();
             };
-            keyboard_box.add(&label);
+            row.add(&label);
         }
 
         self.inner().stack.add(&keyboard);


### PR DESCRIPTION
Gtk's documentation says to implement all of these methods. Less obviously, it turns out the behavior when one doesn't can be weird and inconsistent. This appears to fix the issue.

We'll need to make sure this fixes the issue assembly was seeing, and that it doesn't lead to issues in other cases.