### PR TITLE
chore: Bump version to 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "system76-keyboard-configurator"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "cascade",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system76-keyboard-configurator"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Ian Douglas Scott <idscott@system76.com>", "Jeremy Soller <jeremy@system76.com>"]
 license = "GPL-3.0-or-later"
 edition = "2018"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-keyboard-configurator (1.3.0) focal; urgency=medium
+
+  * 1.3.0 release.
+
+ -- Ian Scott <idscott@system76.com>  Wed, 16 Nov 2022 08:23:08 -0800
+
 system76-keyboard-configurator (1.2.0) focal; urgency=medium
 
   * 1.2.0 release.


### PR DESCRIPTION
From `git shortlog v1.2.0..master`, since the last release we've added galp6, oryp10, and launch_heavy_1, and have the scrolling fix from https://github.com/pop-os/keyboard-configurator/pull/151.

On approval I'll tag a release.