### PR TITLE
Require updated firmware to test

### DIFF
--- a/backend/examples/daemon.rs
+++ b/backend/examples/daemon.rs
@@ -5,17 +5,17 @@ use system76_keyboard_configurator_backend::{run_daemon, Backend};
 fn with_daemon<F: Fn(Backend)>(f: F) {
     if unsafe { libc::geteuid() == 0 } {
         eprintln!("Already running as root");
-        let server = Backend::new().expect("Failed to create server");
+        let server = Backend::new(false).expect("Failed to create server");
         f(server);
         return;
     }
 
-    f(Backend::new_pkexec().unwrap());
+    f(Backend::new_pkexec(false).unwrap());
 }
 
 #[cfg(not(target_os = "linux"))]
 fn with_daemon<F: Fn(Box<dyn Daemon>)>(f: F) {
-    let server = Backend::new().expect("Failed to create server");
+    let server = Backend::new(false).expect("Failed to create server");
     f(server);
 }
 

--- a/backend/src/backend.rs
+++ b/backend/src/backend.rs
@@ -30,6 +30,7 @@ impl ObjectImpl for BackendInner {
             vec![
                 Signal::builder("board-loading", &[], glib::Type::UNIT.into()).build(),
                 Signal::builder("board-loading-done", &[], glib::Type::UNIT.into()).build(),
+                Signal::builder("board-not-updated", &[], glib::Type::UNIT.into()).build(),
                 Signal::builder(
                     "board-added",
                     &[Board::static_type().into()],
@@ -78,6 +79,9 @@ impl Backend {
                         let board = &boards[&id];
                         self_.emit_by_name::<()>("board-removed", &[board]);
                         board.emit_by_name::<()>("removed", &[]);
+                    },
+                    ThreadResponse::BoardNotUpdated => {
+                        self_.emit_by_name::<()>("board-not-updated", &[]);
                     },
                 }
             }),
@@ -136,6 +140,13 @@ impl Backend {
 
     pub fn connect_board_loading_done<F: Fn() + 'static>(&self, cb: F) -> SignalHandlerId {
         self.connect_local("board-loading-done", false, move |_values| {
+            cb();
+            None
+        })
+    }
+
+    pub fn connect_board_not_updated<F: Fn() + 'static>(&self, cb: F) -> SignalHandlerId {
+        self.connect_local("board-not-updated", false, move |_values| {
             cb();
             None
         })

--- a/backend/src/backend.rs
+++ b/backend/src/backend.rs
@@ -57,7 +57,7 @@ glib::wrapper! {
 }
 
 impl Backend {
-    fn new_internal<T: Daemon + 'static>(daemon: T) -> Result<Self, String> {
+    fn new_internal<T: Daemon + 'static>(daemon: T, is_testing_mode: bool) -> Result<Self, String> {
         let self_ = glib::Object::new::<Self>(&[]).unwrap();
         let thread_client = ThreadClient::new(
             Box::new(daemon),
@@ -81,26 +81,27 @@ impl Backend {
                     },
                 }
             }),
+            is_testing_mode
         );
         self_.inner().thread_client.set(thread_client);
         Ok(self_)
     }
 
     pub fn new_dummy(board_names: Vec<String>) -> Result<Self, String> {
-        Self::new_internal(DaemonDummy::new(board_names))
+        Self::new_internal(DaemonDummy::new(board_names), false)
     }
 
     #[cfg(target_os = "linux")]
     pub fn new_s76power() -> Result<Self, String> {
-        Self::new_internal(DaemonS76Power::new()?)
+        Self::new_internal(DaemonS76Power::new()?, false)
     }
 
-    pub fn new_pkexec() -> Result<Self, String> {
-        Self::new_internal(DaemonClient::new_pkexec())
+    pub fn new_pkexec(is_testing_mode: bool) -> Result<Self, String> {
+        Self::new_internal(DaemonClient::new_pkexec(), is_testing_mode)
     }
 
-    pub fn new() -> Result<Self, String> {
-        Self::new_internal(DaemonServer::new_stdio()?)
+    pub fn new(is_testing_mode: bool) -> Result<Self, String> {
+        Self::new_internal(DaemonServer::new_stdio()?, is_testing_mode)
     }
 
     fn inner(&self) -> &BackendInner {

--- a/backend/src/backend.rs
+++ b/backend/src/backend.rs
@@ -85,7 +85,7 @@ impl Backend {
                     },
                 }
             }),
-            is_testing_mode
+            is_testing_mode,
         );
         self_.inner().thread_client.set(thread_client);
         Ok(self_)

--- a/backend/src/backend.rs
+++ b/backend/src/backend.rs
@@ -76,9 +76,10 @@ impl Backend {
                     },
                     ThreadResponse::BoardRemoved(id) => {
                         let boards = self_.inner().boards.borrow();
-                        let board = &boards[&id];
+                        if let Some(board) = &boards.get(&id) {
                         self_.emit_by_name::<()>("board-removed", &[board]);
                         board.emit_by_name::<()>("removed", &[]);
+                        }
                     },
                     ThreadResponse::BoardNotUpdated => {
                         self_.emit_by_name::<()>("board-not-updated", &[]);

--- a/backend/src/benchmark/mod.rs
+++ b/backend/src/benchmark/mod.rs
@@ -75,7 +75,7 @@ impl Benchmark {
                                     best_speed = benchmark;
                                 }
                             }
-                            Err(err) => {
+                            Err(_err) => {
                                 //TODO: do something with error
                             }
                         }

--- a/backend/src/daemon/daemon_thread.rs
+++ b/backend/src/daemon/daemon_thread.rs
@@ -18,7 +18,7 @@ use std::{
     time::Duration,
 };
 
-use super::{Benchmark, BoardId, Daemon, Matrix, Nelson, NelsonKind, is_launch_updated};
+use super::{is_launch_updated, Benchmark, BoardId, Daemon, Matrix, Nelson, NelsonKind};
 use crate::Board;
 
 #[derive(Clone, Debug)]
@@ -116,7 +116,11 @@ pub struct ThreadClient {
 }
 
 impl ThreadClient {
-    pub fn new<F: Fn(ThreadResponse) + 'static>(daemon: Box<dyn Daemon>, cb: F, is_testing_mode: bool) -> Arc<Self> {
+    pub fn new<F: Fn(ThreadResponse) + 'static>(
+        daemon: Box<dyn Daemon>,
+        cb: F,
+        is_testing_mode: bool,
+    ) -> Arc<Self> {
         let (sender, reciever) = async_mpsc::unbounded();
         let client = Arc::new(Self {
             cancels: Mutex::new(HashMap::new()),
@@ -130,7 +134,8 @@ impl ThreadClient {
             }
         });
 
-        let join_handle = Thread::new(daemon, client.clone(), response_sender, is_testing_mode).spawn(reciever);
+        let join_handle =
+            Thread::new(daemon, client.clone(), response_sender, is_testing_mode).spawn(reciever);
         *client.join_handle.lock().unwrap() = Some(join_handle);
         client
     }
@@ -432,7 +437,6 @@ impl Thread {
 
             // If in testing mode and board isn't updated set gui to require update
             board_safe = if self.is_testing_mode {
-
                 let status = is_launch_updated();
                 info!("status = {:?}", status);
                 if (status.is_ok() && status.unwrap()) || status.is_err() {
@@ -445,9 +449,12 @@ impl Thread {
                         .response_channel
                         .unbounded_send(ThreadResponse::BoardNotUpdated);
                     false
-                } else { true }
-
-            } else { true };
+                } else {
+                    true
+                }
+            } else {
+                true
+            };
 
             let (matrix_sender, matrix_reciever) = async_mpsc::unbounded();
             match Board::new(

--- a/backend/src/daemon/daemon_thread.rs
+++ b/backend/src/daemon/daemon_thread.rs
@@ -438,8 +438,7 @@ impl Thread {
             // If in testing mode and board isn't updated set gui to require update
             board_safe = if self.is_testing_mode {
                 let status = is_launch_updated();
-                info!("status = {:?}", status);
-                if (status.is_ok() && status.unwrap()) || status.is_err() {
+                if (status.is_ok() && !status.unwrap()) || status.is_err() {
                     info!("bad board");
                     if let Err(err) = status {
                         warn!("{}", err.to_string());

--- a/backend/src/daemon/fwupdmgr.rs
+++ b/backend/src/daemon/fwupdmgr.rs
@@ -43,8 +43,10 @@ impl Device {
     }
 
     pub fn is_newer_release(self) -> Result<bool, Error> {
-        Ok(self.Releases
-            .as_ref().ok_or(Error::NoRelease)?
+        Ok(self
+            .Releases
+            .as_ref()
+            .ok_or(Error::NoRelease)?
             .into_iter()
             .any(|release| release.created() > self.created()))
     }

--- a/backend/src/daemon/fwupdmgr.rs
+++ b/backend/src/daemon/fwupdmgr.rs
@@ -3,65 +3,51 @@ use std::process::Command;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
-#[allow(non_snake_case)]
+#[serde(rename_all = "PascalCase")]
 struct Devices {
-    pub Devices: Vec<Device>,
+    pub devices: Vec<Device>,
 }
 
 impl Devices {
     pub fn get_launch(self) -> Result<Device, Error> {
-        self.Devices
+        self.devices
             .into_iter()
             .find(|device| {
-                device.name().unwrap_or(&"".to_string()).contains("Launch")
-                    && device.vendor().unwrap_or(&"".to_string()) == "System76"
+                device
+                    .name
+                    .as_ref()
+                    .unwrap_or(&"".to_string())
+                    .contains("Launch")
+                    && device.vendor.as_ref().unwrap_or(&"".to_string()) == "System76"
             })
             .ok_or(Error::NoLaunch)
     }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-#[allow(non_snake_case)]
+#[serde(rename_all = "PascalCase")]
 struct Device {
-    Name: Option<String>,
-    Vendor: Option<String>,
-    Created: usize,
-    Releases: Option<Vec<Release>>,
+    name: Option<String>,
+    vendor: Option<String>,
+    created: usize,
+    releases: Option<Vec<Release>>,
 }
 
 impl Device {
-    pub fn name(&self) -> Option<&String> {
-        self.Name.as_ref()
-    }
-
-    pub fn vendor(&self) -> Option<&String> {
-        self.Vendor.as_ref()
-    }
-
-    pub fn created(&self) -> usize {
-        self.Created
-    }
-
     pub fn is_newer_release(self) -> Result<bool, Error> {
         Ok(self
-            .Releases
+            .releases
             .as_ref()
             .ok_or(Error::NoRelease)?
             .into_iter()
-            .any(|release| release.created() > self.created()))
+            .any(|release| release.created > self.created))
     }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-#[allow(non_snake_case)]
+#[serde(rename_all = "PascalCase")]
 struct Release {
-    Created: usize,
-}
-
-impl Release {
-    pub fn created(&self) -> usize {
-        self.Created
-    }
+    created: usize,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/backend/src/daemon/fwupdmgr.rs
+++ b/backend/src/daemon/fwupdmgr.rs
@@ -1,0 +1,126 @@
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[allow(non_snake_case)]
+struct Devices {
+    pub Devices: Vec<Device>,
+}
+
+impl Devices {
+    pub fn get_launch(self) -> Result<Device, Error> {
+        self.Devices
+            .into_iter()
+            .find(|device| {
+                device.name().unwrap_or(&"".to_string()).contains("Launch")
+                    && device.vendor().unwrap_or(&"".to_string()) == "System76"
+            })
+            .ok_or(Error::NoLaunch)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[allow(non_snake_case)]
+struct Device {
+    Name: Option<String>,
+    Vendor: Option<String>,
+    Created: usize,
+    Releases: Option<Vec<Release>>,
+}
+
+impl Device {
+    pub fn name(&self) -> Option<&String> {
+        self.Name.as_ref()
+    }
+
+    pub fn vendor(&self) -> Option<&String> {
+        self.Vendor.as_ref()
+    }
+
+    pub fn created(&self) -> usize {
+        self.Created
+    }
+
+    pub fn is_newer_release(self) -> Result<bool, Error> {
+        Ok(self.Releases
+            .as_ref().ok_or(Error::NoRelease)?
+            .into_iter()
+            .any(|release| release.created() > self.created()))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[allow(non_snake_case)]
+struct Release {
+    Created: usize,
+}
+
+impl Release {
+    pub fn created(&self) -> usize {
+        self.Created
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum Error {
+    Fwupdmgr,
+    Json,
+    NoLaunch,
+    NoRelease,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::Fwupdmgr => write!(f, "Failed running the fwupdmgr command"),
+            Error::Json => write!(f, "Return data from fwupd was not parsed correctly"),
+            Error::NoLaunch => write!(
+                f,
+                "Unable to find a device with appstream id `com.system76.launch*` via fwupdmgr"
+            ),
+            Error::NoRelease => write!(
+                f,
+                "Unable to find a current release for the connected launch."
+            ),
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(_e: std::io::Error) -> Self {
+        Error::Fwupdmgr
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(_e: std::str::Utf8Error) -> Self {
+        Error::Json
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(_e: serde_json::Error) -> Self {
+        Error::Json
+    }
+}
+
+impl From<std::num::ParseIntError> for Error {
+    fn from(_e: std::num::ParseIntError) -> Self {
+        Error::Json
+    }
+}
+
+pub fn is_launch_updated() -> Result<bool, Error> {
+    // Get all fwupd devices
+    let stdout = Command::new("fwupdmgr")
+        .args(["get-devices", "--json"])
+        .output()?
+        .stdout;
+    info!("before json");
+    let json = std::str::from_utf8(&stdout)?;
+    info!("before devices");
+    let devices: Devices = serde_json::from_str(json).unwrap();
+
+    devices.get_launch()?.is_newer_release()
+}

--- a/backend/src/daemon/fwupdmgr.rs
+++ b/backend/src/daemon/fwupdmgr.rs
@@ -1,5 +1,7 @@
 use std::process::Command;
 
+use once_cell::sync::Lazy;
+use regex::bytes::Regex;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -40,7 +42,7 @@ pub fn is_launch_updated() -> Result<bool, Error> {
         .args(["get-updates", "--json"])
         .output()?
         .stdout;
-    let stdout = std::str::from_utf8(&stdout)?;
 
-    Ok(!stdout.contains("Configurable Keyboard"))
+    static RE: Lazy<Regex> = Lazy::new(|| Regex::new("Launch.* Configurable Keyboard").unwrap());
+    Ok(!RE.is_match(&stdout))
 }

--- a/backend/src/daemon/fwupdmgr.rs
+++ b/backend/src/daemon/fwupdmgr.rs
@@ -4,48 +4,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
-struct Devices {
-    pub devices: Vec<Device>,
-}
-
-impl Devices {
-    pub fn get_launch(self) -> Result<Device, Error> {
-        self.devices
-            .into_iter()
-            .find(|device| {
-                device
-                    .name
-                    .as_ref()
-                    .unwrap_or(&"".to_string())
-                    .contains("Launch")
-                    && device.vendor.as_ref().unwrap_or(&"".to_string()) == "System76"
-            })
-            .ok_or(Error::NoLaunch)
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "PascalCase")]
-struct Device {
-    name: Option<String>,
-    vendor: Option<String>,
-    created: usize,
-    releases: Option<Vec<Release>>,
-}
-
-impl Device {
-    pub fn is_newer_release(self) -> Result<bool, Error> {
-        Ok(self
-            .releases
-            .as_ref()
-            .ok_or(Error::NoRelease)?
-            .into_iter()
-            .any(|release| release.created > self.created))
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "PascalCase")]
 struct Release {
     created: usize,
 }
@@ -53,24 +11,14 @@ struct Release {
 #[derive(Copy, Clone, Debug)]
 pub enum Error {
     Fwupdmgr,
-    Json,
-    NoLaunch,
-    NoRelease,
+    Utf8,
 }
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Error::Fwupdmgr => write!(f, "Failed running the fwupdmgr command"),
-            Error::Json => write!(f, "Return data from fwupd was not parsed correctly"),
-            Error::NoLaunch => write!(
-                f,
-                "Unable to find a device with appstream id `com.system76.launch*` via fwupdmgr"
-            ),
-            Error::NoRelease => write!(
-                f,
-                "Unable to find a current release for the connected launch."
-            ),
+            Error::Utf8 => write!(f, "Return data from fwupd was not parsed correctly"),
         }
     }
 }
@@ -83,32 +31,16 @@ impl From<std::io::Error> for Error {
 
 impl From<std::str::Utf8Error> for Error {
     fn from(_e: std::str::Utf8Error) -> Self {
-        Error::Json
-    }
-}
-
-impl From<serde_json::Error> for Error {
-    fn from(_e: serde_json::Error) -> Self {
-        Error::Json
-    }
-}
-
-impl From<std::num::ParseIntError> for Error {
-    fn from(_e: std::num::ParseIntError) -> Self {
-        Error::Json
+        Error::Utf8
     }
 }
 
 pub fn is_launch_updated() -> Result<bool, Error> {
-    // Get all fwupd devices
     let stdout = Command::new("fwupdmgr")
-        .args(["get-devices", "--json"])
+        .args(["get-updates", "--json"])
         .output()?
         .stdout;
-    info!("before json");
-    let json = std::str::from_utf8(&stdout)?;
-    info!("before devices");
-    let devices: Devices = serde_json::from_str(json).unwrap();
+    let stdout = std::str::from_utf8(&stdout)?;
 
-    devices.get_launch()?.is_newer_release()
+    Ok(!stdout.contains("Configurable Keyboard"))
 }

--- a/backend/src/daemon/mod.rs
+++ b/backend/src/daemon/mod.rs
@@ -5,12 +5,14 @@ use crate::{Benchmark, Matrix, Nelson, NelsonKind};
 mod client;
 mod daemon_thread;
 mod dummy;
+mod fwupdmgr;
 mod server;
 
 #[cfg(target_os = "linux")]
 mod s76power;
 #[cfg(target_os = "linux")]
 pub use self::s76power::*;
+pub use self::fwupdmgr::*;
 
 pub use self::{client::*, daemon_thread::*, dummy::*, server::*};
 

--- a/backend/src/daemon/mod.rs
+++ b/backend/src/daemon/mod.rs
@@ -10,9 +10,9 @@ mod server;
 
 #[cfg(target_os = "linux")]
 mod s76power;
+pub use self::fwupdmgr::*;
 #[cfg(target_os = "linux")]
 pub use self::s76power::*;
-pub use self::fwupdmgr::*;
 
 pub use self::{client::*, daemon_thread::*, dummy::*, server::*};
 

--- a/backend/src/layout/physical_layout.rs
+++ b/backend/src/layout/physical_layout.rs
@@ -5,6 +5,7 @@ use std::char;
 
 use crate::{Rect, Rgb};
 
+#[allow(dead_code)]
 pub(crate) struct PhysicalLayout {
     pub meta: PhysicalLayoutMeta,
     pub keys: Vec<PhysicalLayoutKey>,
@@ -99,6 +100,7 @@ enum PhysicalLayoutEntry {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 pub(crate) struct PhysicalLayoutMeta {
     pub name: String,
     pub author: String,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -3,7 +3,7 @@
 //! ```no_run
 //! use system76_keyboard_configurator_backend::Backend;
 //!
-//! let backend = Backend::new()?;
+//! let backend = Backend::new(false)?;
 //! backend.connect_board_added(|board| {
 //!     println!("{}", board.model());
 //! });

--- a/backend/src/nelson.rs
+++ b/backend/src/nelson.rs
@@ -33,7 +33,7 @@ impl Nelson {
     }
 
     pub fn success(&self, layout: &HashMap<std::string::String, (u8, u8)>) -> bool {
-        let mut values: Vec<&(u8, u8)> = layout.values().collect();
+        let values: Vec<&(u8, u8)> = layout.values().collect();
         for matrix in &[&self.missing, &self.bouncing, &self.sticking] {
             for (row, col) in values.iter() {
                 if matrix.get(*row as usize, *col as usize).unwrap_or(false) {

--- a/i18n/en/system76_keyboard_configurator.ftl
+++ b/i18n/en/system76_keyboard_configurator.ftl
@@ -50,6 +50,7 @@ layout-invert-f-keys = Invert F Keys
 
 loading = Keyboard(s) detected. Loading...
 loading-keyboard = Loading keymap and LEDs for {$keyboard}
+firmware-update-required = Keybaord Firmware Update Required!
 
 page-electrical = Electrical
 page-keycaps = Keycaps

--- a/i18n/en/system76_keyboard_configurator.ftl
+++ b/i18n/en/system76_keyboard_configurator.ftl
@@ -50,7 +50,7 @@ layout-invert-f-keys = Invert F Keys
 
 loading = Keyboard(s) detected. Loading...
 loading-keyboard = Loading keymap and LEDs for {$keyboard}
-firmware-update-required = Keybaord Firmware Update Required!
+firmware-update-required = Keyboard Firmware Update Required!
 
 page-electrical = Electrical
 page-keycaps = Keycaps

--- a/src/main_window.rs
+++ b/src/main_window.rs
@@ -211,7 +211,14 @@ impl MainWindow {
         let backend = cascade! {
             daemon(app.launch_test());
             ..connect_board_loading(clone!(@weak window => move || {
+                info!("loading");
                 let loader = window.display_loader(&fl!("loading"));
+                *window.inner().board_loading.borrow_mut() = Some(loader);
+            }));
+            ..connect_board_not_updated(clone!(@weak window => move || {
+                info!("board not updated");
+                window.inner().board_loading.borrow_mut().take();
+                let loader = window.display_loader(&fl!("firmware-update-required"));
                 *window.inner().board_loading.borrow_mut() = Some(loader);
             }));
             ..connect_board_loading_done(clone!(@weak window => move || {
@@ -374,6 +381,7 @@ impl MainWindow {
     }
 
     pub fn display_loader(&self, text: &str) -> Loader {
+        info!("display loader called with {}", text);
         let load_hbox = cascade! {
             gtk::Box::new(gtk::Orientation::Horizontal, 6);
             ..add(&cascade! {

--- a/src/main_window.rs
+++ b/src/main_window.rs
@@ -412,6 +412,6 @@ fn daemon(is_testing_mode: bool) -> Backend {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn daemon() -> Backend {
+fn daemon(_is_testing_mode: bool) -> Backend {
     Backend::new(false).expect("Failed to create server")
 }

--- a/src/main_window.rs
+++ b/src/main_window.rs
@@ -209,7 +209,7 @@ impl MainWindow {
         app.add_window(&window);
 
         let backend = cascade! {
-            daemon();
+            daemon(app.launch_test());
             ..connect_board_loading(clone!(@weak window => move || {
                 let loader = window.display_loader(&fl!("loading"));
                 *window.inner().board_loading.borrow_mut() = Some(loader);
@@ -392,18 +392,18 @@ impl MainWindow {
 }
 
 #[cfg(target_os = "linux")]
-fn daemon() -> Backend {
+fn daemon(is_testing_mode: bool) -> Backend {
     if unsafe { libc::geteuid() == 0 } {
         info!("Already running as root");
-        Backend::new()
+        Backend::new(is_testing_mode)
     } else {
         info!("Not running as root, spawning daemon with pkexec");
-        Backend::new_pkexec()
+        Backend::new_pkexec(is_testing_mode)
     }
     .expect("Failed to create server")
 }
 
 #[cfg(not(target_os = "linux"))]
 fn daemon() -> Backend {
-    Backend::new().expect("Failed to create server")
+    Backend::new(false).expect("Failed to create server")
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -331,7 +331,7 @@ impl Testing {
                                     }
                                     Err(_) => (),
                                 },
-                                Err(err) => {
+                                Err(_err) => {
                                     // Replace errors with newest results
                                     *bench_result = port_result.clone();
                                 }
@@ -565,6 +565,7 @@ impl Testing {
         TestingInner::from_instance(self)
     }
 
+    #[allow(dead_code)]
     fn keyboard(&self) -> Keyboard {
         self.inner().keyboard.upgrade().unwrap()
     }


### PR DESCRIPTION
This should require that when using the `--launch-test` flag it is impossible to test a keyboard without it having the most recent firmware.

The current behavior is that the `loading` spinner in the top left will change to say that a firmware update is required and never display the keyboard.

This should not effect the keyboard configurator for regular users in any way.