### PR TITLE
Rename fields in structs to increase readability

### DIFF
--- a/backend/src/layout/physical_layout.rs
+++ b/backend/src/layout/physical_layout.rs
@@ -34,9 +34,9 @@ impl PhysicalLayout {
                                 debug!("Key metadata {:?}", meta);
                                 physical.x += meta.x;
                                 physical.y -= meta.y;
-                                physical.w = meta.w.unwrap_or(physical.w);
-                                physical.h = meta.h.unwrap_or(physical.h);
-                                background_color = meta.c.unwrap_or(background_color);
+                                physical.width = meta.width.unwrap_or(physical.width);
+                                physical.height = meta.height.unwrap_or(physical.height);
+                                background_color = meta.color.unwrap_or(background_color);
                             }
                             PhysicalKeyEnum::Name(name) => {
                                 keys.push(PhysicalLayoutKey {
@@ -46,10 +46,10 @@ impl PhysicalLayout {
                                     background_color,
                                 });
 
-                                physical.x += physical.w;
+                                physical.x += physical.width;
 
-                                physical.w = 1.0;
-                                physical.h = 1.0;
+                                physical.width = 1.0;
+                                physical.height = 1.0;
 
                                 col_i += 1;
                             }
@@ -120,7 +120,7 @@ struct PhysicalKeyMeta {
     x: f64,
     #[serde(default)]
     y: f64,
-    w: Option<f64>,
-    h: Option<f64>,
-    c: Option<Rgb>,
+    width: Option<f64>,
+    height: Option<f64>,
+    color: Option<Rgb>,
 }

--- a/backend/src/rect.rs
+++ b/backend/src/rect.rs
@@ -2,17 +2,17 @@
 pub struct Rect {
     pub x: f64,
     pub y: f64,
-    pub w: f64,
-    pub h: f64,
+    pub width: f64,
+    pub height: f64,
 }
 
 impl Rect {
-    pub fn new(x: f64, y: f64, w: f64, h: f64) -> Self {
-        Self { x, y, w, h }
+    pub fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
+        Self { x, y, width, height }
     }
 
     /// Test if `(x, y)` is a point in the rectangle
     pub fn contains(&self, x: f64, y: f64) -> bool {
-        (self.x..=self.x + self.w).contains(&x) && (self.y..=self.y + self.h).contains(&y)
+        (self.x..=self.x + self.width).contains(&x) && (self.y..=self.y + self.height).contains(&y)
     }
 }


### PR DESCRIPTION
Renamed fields in the Rect struct and PhysicalKeyMeta. I believe this will increase readability of the code, as the previous fields, "w", "h", and "c" don't have much meaning.