### PR TITLE
Fix bonw15 keyboard layout

### DIFF
--- a/layouts/system76/bonw15/meta.json
+++ b/layouts/system76/bonw15/meta.json
@@ -3,5 +3,5 @@
   "has_brightness": false,
   "has_color": false,
   "pressed_color": "#dfdfdf",
-  "keyboard": "system76/15in_102_nkey"
+  "keyboard": "system76/15in_102"
 }


### PR DESCRIPTION
It does not use the same layout as the bonw14, it instead uses the layout from the other new RPL devices.