### PR TITLE
Fix Linux, macOS Github Actions, updating to `ubuntu-20.04` runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - run: cargo fmt -- --check
 
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - run: sudo apt-get update && sudo apt-get install cargo libgtk-3-dev libhidapi-dev libudev-dev patchelf
     - uses: actions/checkout@v2

--- a/macos/deploy.py
+++ b/macos/deploy.py
@@ -11,16 +11,16 @@ PREFIX = '/usr/local'
 
 ADWAITA_FILES = [
     'index.theme',
-    'scalable/actions/open-menu-symbolic.svg',
-    'scalable/ui/window-close-symbolic.svg',
-    'scalable/ui/window-maximize-symbolic.svg',
-    'scalable/ui/window-minimize-symbolic.svg',
-    'scalable/ui/window-restore-symbolic.svg',
-    'scalable/actions/edit-delete-symbolic.svg',
-    'scalable/actions/go-previous-symbolic.svg',
-    'scalable/actions/list-remove-symbolic.svg',
-    'scalable/actions/list-add-symbolic.svg',
-    'scalable/actions/edit-find-symbolic.svg',
+    'symbolic/actions/open-menu-symbolic.svg',
+    'symbolic/ui/window-close-symbolic.svg',
+    'symbolic/ui/window-maximize-symbolic.svg',
+    'symbolic/ui/window-minimize-symbolic.svg',
+    'symbolic/ui/window-restore-symbolic.svg',
+    'symbolic/actions/edit-delete-symbolic.svg',
+    'symbolic/actions/go-previous-symbolic.svg',
+    'symbolic/actions/list-remove-symbolic.svg',
+    'symbolic/actions/list-add-symbolic.svg',
+    'symbolic/actions/edit-find-symbolic.svg',
 ]
 ADWAITA_FILES = [f'share/icons/Adwaita/{i}' for i in ADWAITA_FILES]
 ADDITIONAL_FILES = ['share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml'] + ADWAITA_FILES


### PR DESCRIPTION
Apparently if you use a runner name that doesn't exist, Github Actions doesn't tell you and just shows "Waiting for a runner to pick up this job..." until it times out after some number of hours. Including for an old runner that doesn't exist any more. So this should fix the CI builds.

This may make the appimage stop working on some older distros. I doubt many people are trying to run it on anything older than 20.04 anyway? If this is an issue, we can do the build in a Docker container.

I've also cherry-picked the macOS CI fix from https://github.com/pop-os/keyboard-configurator/pull/171 so CI can pass. That one just copies icons from a different path, so it shouldn't impact behavior in any way.