### PR TITLE
Reduce bootloader checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-io"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +76,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-task"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
+
+[[package]]
 name = "atk"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +122,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
 name = "atty"
@@ -116,6 +157,21 @@ name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "blocking"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "log",
+]
 
 [[package]]
 name = "byteorder"
@@ -287,7 +343,7 @@ checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -871,7 +927,7 @@ checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1226,7 +1282,7 @@ dependencies = [
  "libc",
  "log",
  "pin-project-lite",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1433,7 +1489,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1515,6 +1571,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.10",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1628,6 +1703,7 @@ dependencies = [
 name = "system76-keyboard-configurator-backend"
 version = "0.1.0"
 dependencies = [
+ "async-process",
  "cascade",
  "futures",
  "futures-timer",
@@ -1873,7 +1949,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1882,13 +1967,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -1898,10 +1998,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1910,10 +2022,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1922,16 +2046,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -6,6 +6,7 @@ license = "GPL-3.0-or-later"
 edition = "2018"
 
 [dependencies]
+async-process = "1.7.0"
 cascade = "1"
 futures = "0.3.13"
 futures-timer = "3.0.2"

--- a/backend/src/backend.rs
+++ b/backend/src/backend.rs
@@ -126,11 +126,20 @@ impl Backend {
     /// Test for added/removed boards, emitting `board-added`/`board-removed` signals
     ///
     /// This function does not block, and loads new boards in the background.
-    pub fn refresh(&self, is_testing_mode: bool) {
+    pub fn refresh(&self) {
         let self_ = self.clone();
         glib::MainContext::default().spawn_local(async move {
-            if let Err(err) = self_.inner().thread_client.refresh(is_testing_mode).await {
+            if let Err(err) = self_.inner().thread_client.refresh().await {
                 error!("Failed to refresh boards: {}", err);
+            }
+        });
+    }
+
+    pub fn check_for_bootloader(&self) {
+        let self_ = self.clone();
+        glib::MainContext::default().spawn_local(async move {
+            if let Err(err) = self_.inner().thread_client.check_for_bootloader().await {
+                error!("Failed to check for board in bootloader mode: {}", err);
             }
         });
     }

--- a/backend/src/board.rs
+++ b/backend/src/board.rs
@@ -63,7 +63,7 @@ impl ObjectImpl for BoardInner {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Hash, Eq)]
 pub enum Bootloaded {
     // Launch 2, Launch Heavy 1,
     At90usb646,

--- a/backend/src/daemon/dummy.rs
+++ b/backend/src/daemon/dummy.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, collections::HashMap};
 
 use super::{BoardId, Daemon};
-use crate::{fl, Benchmark, Bootloaded, Layout, Matrix, Nelson, NelsonKind};
+use crate::{fl, Benchmark, Layout, Matrix, Nelson, NelsonKind};
 
 struct BoardDummy {
     name: String,
@@ -60,11 +60,6 @@ impl DaemonDummy {
 impl Daemon for DaemonDummy {
     fn boards(&self) -> Result<Vec<BoardId>, String> {
         Ok((0..self.boards.len() as u128).map(BoardId).collect())
-    }
-
-    fn bootloaded_board(&self) -> Result<(Option<Bootloaded>, Option<Bootloaded>), String> {
-        // (prev, current)
-        Ok((None, None))
     }
 
     fn model(&self, board: BoardId) -> Result<String, String> {
@@ -171,7 +166,7 @@ impl Daemon for DaemonDummy {
         Ok(())
     }
 
-    fn refresh(&self, _is_testing_mode: bool) -> Result<(), String> {
+    fn refresh(&self) -> Result<(), String> {
         Ok(())
     }
 

--- a/backend/src/daemon/mod.rs
+++ b/backend/src/daemon/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{Benchmark, Bootloaded, Matrix, Nelson, NelsonKind};
+use crate::{Benchmark, Matrix, Nelson, NelsonKind};
 
 mod client;
 mod daemon_thread;
@@ -79,10 +79,9 @@ macro_rules! commands {
 
 commands! {
     fn boards(&self) -> Result<Vec<BoardId>, String>;
-    fn bootloaded_board(&self) -> Result<(Option<Bootloaded>, Option<Bootloaded>), String>;
     fn model(&self, board: BoardId) -> Result<String, String>;
     fn version(&self, board: BoardId) -> Result<String, String>;
-    fn refresh(&self, is_testing_mode: bool) -> Result<(), String>;
+    fn refresh(&self) -> Result<(), String>;
     fn keymap_get(&self, board: BoardId, layer: u8, output: u8, input: u8) -> Result<u16, String>;
     fn keymap_set(&self, board: BoardId, layer: u8, output: u8, input: u8, value: u16) -> Result<(), String>;
     fn matrix_get(&self, board: BoardId) -> Result<Matrix, String>;

--- a/backend/src/daemon/s76power.rs
+++ b/backend/src/daemon/s76power.rs
@@ -6,7 +6,7 @@ use std::iter::Iterator;
 use zbus::{dbus_proxy, fdo::ObjectManagerProxy, Connection};
 
 use super::{err_str, BoardId, Daemon, Matrix};
-use crate::{fl, Benchmark, Bootloaded, Nelson, NelsonKind, Rgb};
+use crate::{fl, Benchmark, Nelson, NelsonKind, Rgb};
 
 const DBUS_NAME: &str = "com.system76.PowerDaemon";
 
@@ -78,11 +78,6 @@ impl DaemonS76Power {
 impl Daemon for DaemonS76Power {
     fn boards(&self) -> Result<Vec<BoardId>, String> {
         Ok((0..self.boards.len() as u128).map(BoardId).collect())
-    }
-
-    fn bootloaded_board(&self) -> Result<(Option<Bootloaded>, Option<Bootloaded>), String> {
-        // (prev, current)
-        Ok((None, None))
     }
 
     fn model(&self, _board: BoardId) -> Result<String, String> {
@@ -178,7 +173,7 @@ impl Daemon for DaemonS76Power {
         Err("Unimplemented".to_string())
     }
 
-    fn refresh(&self, _is_testing_mode: bool) -> Result<(), String> {
+    fn refresh(&self) -> Result<(), String> {
         Ok(())
     }
 

--- a/backend/src/daemon/server.rs
+++ b/backend/src/daemon/server.rs
@@ -2,12 +2,10 @@
 use ectool::AccessLpcLinux;
 use ectool::{Access, AccessHid, Ec};
 use hidapi::{DeviceInfo, HidApi};
-use once_cell::sync::Lazy;
 use std::{
     cell::{Cell, RefCell, RefMut},
     collections::HashMap,
     io::{self, BufRead, BufReader, Read, Write},
-    process::Command,
     str,
     thread::sleep,
     time::Duration,
@@ -15,7 +13,7 @@ use std::{
 use uuid::Uuid;
 
 use super::{err_str, BoardId, Daemon, DaemonCommand};
-use crate::{Benchmark, Bootloaded, Matrix, Nelson, NelsonKind};
+use crate::{Benchmark, Matrix, Nelson, NelsonKind};
 
 #[allow(clippy::type_complexity)]
 pub struct DaemonServer<R: Read + Send + 'static, W: Write + Send + 'static> {
@@ -26,8 +24,6 @@ pub struct DaemonServer<R: Read + Send + 'static, W: Write + Send + 'static> {
     boards: RefCell<HashMap<BoardId, (Ec<Box<dyn Access>>, Option<DeviceInfo>)>>,
     board_ids: RefCell<Vec<BoardId>>,
     nelson: RefCell<Option<Ec<AccessHid>>>,
-    prev_bootloaded: RefCell<Option<Bootloaded>>,
-    bootloaded: RefCell<Option<Bootloaded>>,
 }
 
 impl DaemonServer<io::Stdin, io::Stdout> {
@@ -76,8 +72,6 @@ impl<R: Read + Send + 'static, W: Write + Send + 'static> DaemonServer<R, W> {
             boards: RefCell::new(boards),
             board_ids: RefCell::new(board_ids),
             nelson: RefCell::new(None),
-            prev_bootloaded: RefCell::new(None),
-            bootloaded: RefCell::new(None),
         })
     }
 
@@ -128,10 +122,6 @@ impl<R: Read + Send + 'static, W: Write + Send + 'static> DaemonServer<R, W> {
 impl<R: Read + Send + 'static, W: Write + Send + 'static> Daemon for DaemonServer<R, W> {
     fn boards(&self) -> Result<Vec<BoardId>, String> {
         Ok(self.board_ids.borrow().clone())
-    }
-
-    fn bootloaded_board(&self) -> Result<(Option<Bootloaded>, Option<Bootloaded>), String> {
-        Ok((*self.prev_bootloaded.borrow(), *self.bootloaded.borrow()))
     }
 
     fn model(&self, board: BoardId) -> Result<String, String> {
@@ -292,7 +282,7 @@ impl<R: Read + Send + 'static, W: Write + Send + 'static> Daemon for DaemonServe
         unsafe { ec.led_save().map_err(err_str) }
     }
 
-    fn refresh(&self, is_testing_mode: bool) -> Result<(), String> {
+    fn refresh(&self) -> Result<(), String> {
         if let Some(api) = &mut *self.hidapi.borrow_mut() {
             // Remove USB boards that are no longer attached
             {
@@ -307,38 +297,6 @@ impl<R: Read + Send + 'static, W: Write + Send + 'static> Daemon for DaemonServe
 
             if let Err(err) = api.refresh_devices() {
                 error!("Failed to refresh hidapi devices: {}", err);
-            }
-
-            // Check for keybaords that are plugged in and are in bootloader mode.
-            // Then
-            if is_testing_mode {
-                use regex::bytes::Regex;
-                static HAS_USB_HUB: Lazy<Regex> =
-                    Lazy::new(|| Regex::new("3384:000.*System76 USB").unwrap());
-                static ATMEGA32U4: Lazy<Regex> =
-                    Lazy::new(|| Regex::new("03eb:2ff4.*atmega32u4.*bootloader").unwrap());
-                static AT90USB646: Lazy<Regex> =
-                    Lazy::new(|| Regex::new("03eb:2ff9.*at90usb646.*bootloader").unwrap());
-
-                *self.prev_bootloaded.borrow_mut() = *self.bootloaded.borrow();
-
-                let lsusb = Command::new("lsusb")
-                    .arg("--verbose")
-                    .output()
-                    .map_err(|_| "Failed to run lsusb".to_string())?
-                    .stdout;
-
-                if AT90USB646.is_match(&lsusb) {
-                    if HAS_USB_HUB.is_match(&lsusb) {
-                        *self.bootloaded.borrow_mut() = Some(Bootloaded::At90usb646);
-                    } else {
-                        *self.bootloaded.borrow_mut() = Some(Bootloaded::At90usb646Lite);
-                    }
-                } else if ATMEGA32U4.is_match(&lsusb) {
-                    *self.bootloaded.borrow_mut() = Some(Bootloaded::AtMega32u4);
-                } else {
-                    *self.bootloaded.borrow_mut() = None;
-                }
             }
 
             for info in api.device_list() {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -7,7 +7,7 @@
 //! backend.connect_board_added(|board| {
 //!     println!("{}", board.model());
 //! });
-//! backend.refresh(false);
+//! backend.refresh();
 //! # Ok::<(), String>(())
 //! ```
 

--- a/src/main_window.rs
+++ b/src/main_window.rs
@@ -259,7 +259,7 @@ impl MainWindow {
             ..connect_bootloader_lite_added(clone!(@weak window => move |board| window.add_flash_menu(board)));
             ..connect_bootloader_board_removed(clone!(@weak window => move || window.remove_flash_menu()));
           }
-        } else {&mut backend}.refresh(is_testing_mode);
+        } else {&mut backend}.refresh();
 
         // Refresh key matrix only when window is visible
         backend.set_matrix_get_rate(if window.is_active() {
@@ -282,7 +282,7 @@ impl MainWindow {
                     backend.connect_board_added(
                         clone!(@weak window => move |board| window.add_keyboard(board)),
                     );
-                    backend.refresh(is_testing_mode);
+                    backend.refresh();
                 }
                 Err(err) => error!("{}", err),
             }
@@ -294,7 +294,11 @@ impl MainWindow {
             1,
             clone!(@weak window => @default-return glib::Continue(false), move || {
                 if !REFRESH_DISABLED.load(Ordering::Relaxed) {
-                  window.inner().backend.refresh(**window.inner().is_testing_mode.borrow());
+                  let inner = window.inner();
+                  inner.backend.refresh();
+                  if **inner.is_testing_mode.borrow() && !inner.back_button.is_visible() {
+                      inner.backend.check_for_bootloader()
+                  }
                 }
                 glib::Continue(true)
             }),

--- a/widgets/src/keyboard_backlight_widget.rs
+++ b/widgets/src/keyboard_backlight_widget.rs
@@ -41,7 +41,7 @@ fn add_boards(stack: &gtk::Stack) -> Result<(), String> {
         let name = board.model().to_owned();
         stack.add_titled(&page(board), &name, &name);
     }));
-    backend.refresh(false);
+    backend.refresh();
 
     Ok(())
 }


### PR DESCRIPTION
1. Only check for connected boards in bootloader mode when on the main page
2. Run `lsusb` as async command rather than blocking
3. Remove is_test_mode bool from `refresh`, now checking for bootloader isn't handled by any unique backend.
4. checking for bootloader is now separate from generic refresh

This fixes a bug production was having where the key press animation on the rendered keyboard would lag on their slow meerkats.