### PR TITLE
i18n(it): Add Italian language support

### DIFF
--- a/i18n/it/system76_keyboard_configurator.ftl
+++ b/i18n/it/system76_keyboard_configurator.ftl
@@ -1,0 +1,91 @@
+-name = Configuratore Tastiera
+
+app-about = About {-name}
+app-title = System76 {-name}
+
+board-fake = {$model}, falso
+
+button-cancel = Annulla
+button-configure = Configura Tastiera
+button-disable = Disabilita
+button-import = Importa
+button-test = Prova
+button-start = Inizia
+button-stop = Termina
+
+error-disable-key = Disabilitazione tasto fallita
+error-export-keymap = Esportazione mappa della tastiera fallita
+error-import-keymap = Importazione mappa della tastiera fallita
+error-key-led = Impostazione LED fallita
+error-open-file = Apertura file fallita
+error-save-leds = Salvataggio LED fallito
+error-set-keyboard-brightness = Impostazione luminosità fallita
+error-set-keyboard-mode = Impostazione modalità tastiera fallita
+error-set-keymap = Impostazione mappa della tastiera fallita
+error-set-layer-brightness = Impostazione luminosità livello fallita
+error-set-layer-color = Impostazione colore livello fallita
+error-set-layer-mode = Impostazione modalità a livelli fallita
+error-unsupported-keymap = File mappa della tastiera non supportato
+error-unsupported-keymap-desc = Il file mappa della tastiera, sembra provenire da una nuova versione del Configuratore.
+
+firmware-version = La versione {$version} del firmware non supporta la configurazione della mappa della tastiera.
+
+keyboard-brightness = Luminosità:
+keyboard-color = Colore:
+
+key-color = Colore Tasto:
+
+keymap-for-board = La mappa della tastiera è per il modello '{$model}'
+
+layer-all-brightness = Luminosità (tutti i livelli):
+layer-animation-speed = Velocità Animazione Livello:
+layer-color = Colore Livello:
+layer-color-pattern = Modello Colore Livello:
+layer-saturation = Saturazione Livello:
+
+layout-export = Esporta Disposizione
+layout-import = Importa Disposizione
+layout-reset = Ripristina Disposizione
+layout-invert-f-keys = Inverti Tasti F
+
+flash-to-launch-heavy = Flash to Launch Heavy 1
+flash-to-launch-2 = Flash to Launch 2
+flash-to-launch-1 = Flash to Launch 1
+flash-to-launch-lite-1 = Flash to Launch Lite 1
+
+loading = Tastiera rilevata. Caricamento...
+loading-keyboard = Caricamento mappa della tastiera e LED per {$keyboard}
+firmware-update-required = È necessario aggiornare il firmware della tastiera!
+
+page-electrical = Elettrica
+page-keycaps = Copritasti
+page-layer1 = Livello 1
+page-layer2 = Livello 2
+page-layer3 = Livello 3
+page-layer4 = Livello 4
+page-leds = LED
+page-logical = Logica
+
+no-boards = Nessuna tastiera rilevata
+no-boards-msg = Assicurarsi di che la tastiera integrata abbia l'ultima versione dell'Open Firmware System76.
+ Se si sta utilizzando una tastiera esterna, assicurarsi che sia connessa correttamente
+
+show-help-overlay = Scorciatoie Tastiera
+
+stack-keymap = Mappa tastiera
+stack-keymap-desc =
+ Seleziona un tasto sulla mappa per cambiare le sue impostazioni. Maiusc + click per selezionarne più di uno. Le tue impostazioni sono salvate automaticamente sul firmware.
+
+stack-leds = LED
+stack-leds-desc = Seleziona un tasto sulla mappa per cambiare le sue impostazioni. Scegli una tinta unica per modello, per personalizzare il colore del LED per ogni tasto. Maiusc + click per selezionarne più di uno. Le tue impostazioni sono salvate automaticamente sul firmware.
+stack-leds-desc-builtin = Le impostazioni dei LED saranno ripristinate dopo il riavvio. In futuro arriveranno altre funzionalità.
+
+stack-testing = Testing
+
+test-check-pins = Controlla perno (mancante)
+test-check-key = Controlla tasto (aderenza)
+test-number-of-runs = Numero di esecuzioni
+test-replace-switch = Sostituisci tasto
+test-spurious-keypress = Pressione spuria del tasto
+
+untitled-layout = Layout Senza Titolo

--- a/i18n/it/system76_keyboard_configurator_backend.ftl
+++ b/i18n/it/system76_keyboard_configurator_backend.ftl
@@ -1,0 +1,17 @@
+mode-disabled = Disabilitato
+mode-solid-color = Tinta Unita Per Strato
+mode-per-key = Colore Per Tasto
+mode-active-keys = Solo Tasti Vincolati
+mode-cycle-all = Background Cosmic
+mode-cycle-left-right = Scansione Orizzontale
+mode-cycle-up-down = Scansione Verticale
+mode-cycle-out-in = Orizzonte Degli Eventi
+mode-cycle-out-in-dual = Galassie Binarie
+mode-rainbow-moving-chevron = Spaziotempo
+mode-cycle-pinwheel = Galassia Girandola
+mode-cycle-spiral = Galassia Spirale
+mode-raindrops = Elementi
+mode-splash = Splashdown
+mode-multisplash = Pioggia Di Meteore
+
+no-board = Nessuna tavola

--- a/i18n/it/system76_keyboard_configurator_widgets.ftl
+++ b/i18n/it/system76_keyboard_configurator_widgets.ftl
@@ -1,0 +1,13 @@
+button-color = Colore
+button-cancel = Annulla
+button-save = Salva
+
+choose-color = Imposta Colore
+
+error-set-color = Impostazione colore della tastiera fallito
+error-set-brightness = Impostazione luminosità della tastiera fallito
+
+label-hue = Tonalità
+label-saturation = Saturazione
+
+scale-brightness = Luminosità

--- a/i18n/nl/system76_keyboard_configurator.ftl
+++ b/i18n/nl/system76_keyboard_configurator.ftl
@@ -60,7 +60,7 @@ page-logical = Logisch
 no-boards = Er is geen toetsenbord aangetroffen
 no-boards-msg = Zorg er voor dat uw toetsenbord beschikt over de nieuwste
  System76 Open Firmware.
-Als u gebruikmaakt van een extern toetsenbord, zorg er dan voor dat
+ Als u gebruikmaakt van een extern toetsenbord, zorg er dan voor dat
  het toetsenbord goed is aangesloten.
 
 show-help-overlay = Sneltoetsen

--- a/i18n/sl/system76_keyboard_configurator.ftl
+++ b/i18n/sl/system76_keyboard_configurator.ftl
@@ -33,7 +33,7 @@ keyboard-color = Barva:
 
 key-color = Barva tipke:
 
-keymap-for-board = Mapa tipk je za ploščo '{$ model}'
+keymap-for-board = Mapa tipk je za ploščo '{$model}'
 
 layer-all-brightness = Svetlost (vsi sloji):
 layer-animation-speed = Hitrost animacije sloja:


### PR DESCRIPTION
Notes on the translation:
- I didn't translate the flash-to-launch section to avoid mistakes, since the context is not clear and there is no direct translation to those phrases.

Extra: I fixed a couple of formatting issues in the sl and nl translations.