### PR TITLE
Fix for legacy layout for 0.7.104

### DIFF
--- a/backend/src/layout/mod.rs
+++ b/backend/src/layout/mod.rs
@@ -138,7 +138,9 @@ impl Layout {
     }
 
     pub fn from_board(board: &str, version: &str) -> Option<Self> {
-        let use_legacy_scancodes = version.contains("0.7.103") || version.contains("0.12.20");
+        let use_legacy_scancodes = version.contains("0.7.103")
+            || version.contains("0.7.104")
+            || version.contains("0.12.20");
         layout_data(board, use_legacy_scancodes).map(
             |(meta_json, default_json, keymap_json, layout_json, leds_json, physical_json)| {
                 Self::from_data(
@@ -220,7 +222,7 @@ mod tests {
     use super::*;
     use std::{collections::HashSet, fs, io};
 
-    const VERSIONS: [&str; 2] = ["0.7.103", "0.19.12"];
+    const VERSIONS: [&str; 3] = ["0.7.103", "0.7.104", "0.19.12"];
 
     #[test]
     fn layout_from_board() {

--- a/layouts.py
+++ b/layouts.py
@@ -297,7 +297,7 @@ def extract_scancodes(ecdir: str, board: str, is_qmk: bool, has_brightness: bool
     is_old_qmk = False
     if is_qmk:
         version = subprocess.check_output(["git", "-C", ecdir, "describe", "--tags"], stderr=subprocess.DEVNULL, universal_newlines=True)
-        is_old_qmk = "0.7.103" in version or "0.12.20" in version
+        is_old_qmk = "0.7.103" in version or "0.7.104" in version or "0.12.20" in version
         if is_old_qmk:
             include_paths = [f"{ecdir}/tmk_core/common/keycode.h", f"{ecdir}/quantum/quantum_keycodes.h", f"{ecdir}/tmk_core/common/action_code.h"]
             includes = [read_stripping_includes(i) for i in include_paths]


### PR DESCRIPTION
Because of a temp hack to fix fwupd.
This version also requires the legacy scancode maps.

We should do a keyboard configurator release after this is merged