### PR TITLE
fix: Update Adwaita icon directories in Windows build script

### DIFF
--- a/windows/build.py
+++ b/windows/build.py
@@ -31,16 +31,16 @@ DLL_RE = r"(?<==> )(.*\\mingw32)\\bin\\(\S+.dll)"
 
 ADWAITA_FILES = [
     'index.theme',
-    'scalable/actions/open-menu-symbolic.svg',
-    'scalable/ui/window-close-symbolic.svg',
-    'scalable/ui/window-maximize-symbolic.svg',
-    'scalable/ui/window-minimize-symbolic.svg',
-    'scalable/ui/window-restore-symbolic.svg',
-    'scalable/actions/edit-delete-symbolic.svg',
-    'scalable/actions/go-previous-symbolic.svg',
-    'scalable/actions/list-remove-symbolic.svg',
-    'scalable/actions/list-add-symbolic.svg',
-    'scalable/actions/edit-find-symbolic.svg',
+    'symbolic/actions/open-menu-symbolic.svg',
+    'symbolic/ui/window-close-symbolic.svg',
+    'symbolic/ui/window-maximize-symbolic.svg',
+    'symbolic/ui/window-minimize-symbolic.svg',
+    'symbolic/ui/window-restore-symbolic.svg',
+    'symbolic/actions/edit-delete-symbolic.svg',
+    'symbolic/actions/go-previous-symbolic.svg',
+    'symbolic/actions/list-remove-symbolic.svg',
+    'symbolic/actions/list-add-symbolic.svg',
+    'symbolic/actions/edit-find-symbolic.svg',
 ]
 ADWAITA_FILES = [f'share/icons/Adwaita/{i}' for i in ADWAITA_FILES]
 ADDITIONAL_FILES = ['share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml', 'share/icons/hicolor/index.theme', 'lib/p11-kit', 'lib/gdk-pixbuf-2.0'] + ADWAITA_FILES


### PR DESCRIPTION
The Windows build is currently failing:
```
Copy ../data/icons/scalable -> out/share/icons/Adwaita/scalable
Copy D:\a\_temp\msys64\mingw32/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml -> out/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml
Copy D:\a\_temp\msys64\mingw32/share/icons/hicolor/index.theme -> out/share/icons/hicolor/index.theme
Copy D:\a\_temp\msys64\mingw32/lib/p11-kit -> out/lib/p11-kit
Copy D:\a\_temp\msys64\mingw32/lib/gdk-pixbuf-2.0 -> out/lib/gdk-pixbuf-2.0
Copy D:\a\_temp\msys64\mingw32/share/icons/Adwaita/index.theme -> out/share/icons/Adwaita/index.theme
Copy D:\a\_temp\msys64\mingw32/share/icons/Adwaita/scalable/actions/open-menu-symbolic.svg -> out/share/icons/Adwaita/scalable/actions/open-menu-symbolic.svg
Traceback (most recent call last):
  File "D:\a\keyboard-configurator\keyboard-configurator\windows\build.py", line 111, in <module>
    copy(mingw_dir, 'out', i)
  File "D:\a\keyboard-configurator\keyboard-configurator\windows\build.py", line 88, in copy
    shutil.copy(src, dest)
  File "D:/a/_temp/msys64/mingw32/lib/python3.10/shutil.py", line 417, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "D:/a/_temp/msys64/mingw32/lib/python3.10/shutil.py", line 254, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: 'D:\\a\\_temp\\msys64\\mingw32/share/icons/Adwaita/scalable/actions/open-menu-symbolic.svg'
Error: Process completed with exit code 1.
```

Looking at the [Adwaita icon theme repo](https://gitlab.gnome.org/GNOME/adwaita-icon-theme), it looks like the icons in use have been moved to a different directory (or replaced with ones in a different directory.) The macOS build script already points to the `symbolic` directory, but the Windows script is currently still pointing towards `scalable`, so this updates the Windows script to point to `symbolic`.

May fix https://github.com/pop-os/keyboard-configurator/issues/191.