### PR TITLE
Add `MIC_MUTE` key for builtin keyboards

### DIFF
--- a/backend/src/layout/mod.rs
+++ b/backend/src/layout/mod.rs
@@ -263,6 +263,7 @@ mod tests {
                     || k == "FAN_TOGGLE"
                     || k == "CAMERA_TOGGLE"
                     || k == "AIRPLANE_MODE"
+                    || k == "MIC_MUTE"
                 {
                     continue;
                 }

--- a/layouts/keyboards/overrides/0.19.12/system76/14in_83/keymap.json
+++ b/layouts/keyboards/overrides/0.19.12/system76/14in_83/keymap.json
@@ -1,4 +1,5 @@
 {
+  "NONE": 0,
   "FN": 4096,
   "DISPLAY_MODE": 8192,
   "PRINT_SCREEN": 8193,
@@ -21,6 +22,7 @@
   "MEDIA_NEXT": 333,
   "MEDIA_PREV": 277,
   "TOUCHPAD": 355,
+  "MIC_MUTE": 374,
   "F1": 5,
   "F2": 6,
   "F3": 4,
@@ -122,6 +124,5 @@
   "NUM_6": 116,
   "NUM_7": 108,
   "NUM_8": 117,
-  "NUM_9": 125,
-  "NONE": 0
+  "NUM_9": 125
 }

--- a/layouts/keyboards/overrides/0.19.12/system76/14in_86/keymap.json
+++ b/layouts/keyboards/overrides/0.19.12/system76/14in_86/keymap.json
@@ -1,4 +1,5 @@
 {
+  "NONE": 0,
   "FN": 4096,
   "DISPLAY_MODE": 8192,
   "PRINT_SCREEN": 8193,
@@ -21,6 +22,7 @@
   "MEDIA_NEXT": 333,
   "MEDIA_PREV": 277,
   "TOUCHPAD": 355,
+  "MIC_MUTE": 374,
   "F1": 5,
   "F2": 6,
   "F3": 4,
@@ -122,6 +124,5 @@
   "NUM_6": 116,
   "NUM_7": 108,
   "NUM_8": 117,
-  "NUM_9": 125,
-  "NONE": 0
+  "NUM_9": 125
 }

--- a/layouts/keyboards/overrides/0.19.12/system76/15in_102/keymap.json
+++ b/layouts/keyboards/overrides/0.19.12/system76/15in_102/keymap.json
@@ -1,4 +1,5 @@
 {
+  "NONE": 0,
   "FN": 4096,
   "DISPLAY_MODE": 8192,
   "PRINT_SCREEN": 8193,
@@ -21,6 +22,7 @@
   "MEDIA_NEXT": 333,
   "MEDIA_PREV": 277,
   "TOUCHPAD": 355,
+  "MIC_MUTE": 374,
   "F1": 5,
   "F2": 6,
   "F3": 4,
@@ -122,6 +124,5 @@
   "NUM_6": 116,
   "NUM_7": 108,
   "NUM_8": 117,
-  "NUM_9": 125,
-  "NONE": 0
+  "NUM_9": 125
 }

--- a/layouts/keyboards/overrides/0.19.12/system76/15in_102_nkey/keymap.json
+++ b/layouts/keyboards/overrides/0.19.12/system76/15in_102_nkey/keymap.json
@@ -1,4 +1,5 @@
 {
+  "NONE": 0,
   "FN": 4096,
   "DISPLAY_MODE": 8192,
   "PRINT_SCREEN": 8193,
@@ -21,6 +22,7 @@
   "MEDIA_NEXT": 333,
   "MEDIA_PREV": 277,
   "TOUCHPAD": 355,
+  "MIC_MUTE": 374,
   "F1": 5,
   "F2": 6,
   "F3": 4,
@@ -122,6 +124,5 @@
   "NUM_6": 116,
   "NUM_7": 108,
   "NUM_8": 117,
-  "NUM_9": 125,
-  "NONE": 0
+  "NUM_9": 125
 }

--- a/layouts/keyboards/system76/14in_83/keymap.json
+++ b/layouts/keyboards/system76/14in_83/keymap.json
@@ -1,4 +1,5 @@
 {
+  "NONE": 0,
   "FN": 4096,
   "DISPLAY_MODE": 8192,
   "PRINT_SCREEN": 8193,
@@ -21,6 +22,7 @@
   "MEDIA_NEXT": 333,
   "MEDIA_PREV": 277,
   "TOUCHPAD": 355,
+  "MIC_MUTE": 374,
   "F1": 5,
   "F2": 6,
   "F3": 4,
@@ -122,6 +124,5 @@
   "NUM_6": 116,
   "NUM_7": 108,
   "NUM_8": 117,
-  "NUM_9": 125,
-  "NONE": 0
+  "NUM_9": 125
 }

--- a/layouts/keyboards/system76/14in_86/keymap.json
+++ b/layouts/keyboards/system76/14in_86/keymap.json
@@ -1,4 +1,5 @@
 {
+  "NONE": 0,
   "FN": 4096,
   "DISPLAY_MODE": 8192,
   "PRINT_SCREEN": 8193,
@@ -21,6 +22,7 @@
   "MEDIA_NEXT": 333,
   "MEDIA_PREV": 277,
   "TOUCHPAD": 355,
+  "MIC_MUTE": 374,
   "F1": 5,
   "F2": 6,
   "F3": 4,
@@ -122,6 +124,5 @@
   "NUM_6": 116,
   "NUM_7": 108,
   "NUM_8": 117,
-  "NUM_9": 125,
-  "NONE": 0
+  "NUM_9": 125
 }

--- a/layouts/keyboards/system76/15in_102/keymap.json
+++ b/layouts/keyboards/system76/15in_102/keymap.json
@@ -1,4 +1,5 @@
 {
+  "NONE": 0,
   "FN": 4096,
   "DISPLAY_MODE": 8192,
   "PRINT_SCREEN": 8193,
@@ -21,6 +22,7 @@
   "MEDIA_NEXT": 333,
   "MEDIA_PREV": 277,
   "TOUCHPAD": 355,
+  "MIC_MUTE": 374,
   "F1": 5,
   "F2": 6,
   "F3": 4,
@@ -122,6 +124,5 @@
   "NUM_6": 116,
   "NUM_7": 108,
   "NUM_8": 117,
-  "NUM_9": 125,
-  "NONE": 0
+  "NUM_9": 125
 }

--- a/layouts/keyboards/system76/15in_102_nkey/keymap.json
+++ b/layouts/keyboards/system76/15in_102_nkey/keymap.json
@@ -1,4 +1,5 @@
 {
+  "NONE": 0,
   "FN": 4096,
   "DISPLAY_MODE": 8192,
   "PRINT_SCREEN": 8193,
@@ -21,6 +22,7 @@
   "MEDIA_NEXT": 333,
   "MEDIA_PREV": 277,
   "TOUCHPAD": 355,
+  "MIC_MUTE": 374,
   "F1": 5,
   "F2": 6,
   "F3": 4,
@@ -122,6 +124,5 @@
   "NUM_6": 116,
   "NUM_7": 108,
   "NUM_8": 117,
-  "NUM_9": 125,
-  "NONE": 0
+  "NUM_9": 125
 }

--- a/layouts/picker.json
+++ b/layouts/picker.json
@@ -519,6 +519,10 @@
       {
         "keysym": "MEDIA_PREV",
         "label": "Prev Track"
+      },
+      {
+        "keysym": "MIC_MUTE",
+        "label": "Mic Mute"
       }
     ]
   },


### PR DESCRIPTION
Should this be in "Media" section?

For some reason this doesn't seem to work when I test it...