### PR TITLE
Revert Nelson test delay to 300ms

### DIFF
--- a/backend/src/daemon/server.rs
+++ b/backend/src/daemon/server.rs
@@ -180,7 +180,7 @@ impl<R: Read + Send + 'static, W: Write + Send + 'static> Daemon for DaemonServe
 
     fn nelson(&self, board: BoardId, kind: NelsonKind) -> Result<Nelson, String> {
         if let Some(nelson) = &mut *self.nelson.borrow_mut() {
-            const DELAY_MS: u64 = 130;
+            const DELAY_MS: u64 = 300;
             info!("Nelson delay is {} ms", DELAY_MS);
             let delay = Duration::from_millis(DELAY_MS);
 


### PR DESCRIPTION
8296d0965972f4a66ab414cab2e7062bb649d59e reduced the delay to make testing faster, but it seems to fail inconsistently. Let's see if this fixes it.