### PR TITLE
macos: Notarize app with `notarytool` instead of `altool --notarize-app`

### DIFF
--- a/macos/signing.sh
+++ b/macos/signing.sh
@@ -27,12 +27,12 @@ security set-key-partition-list -S apple-tool:,apple: -s -k "${PASSWORD}" "${KEY
 security delete-keychain "${KEYCHAIN}"
 
 # Submit for notarization
-xcrun altool \
-    --notarize-app \
-    --primary-bundle-id com.system76.keyboardconfigurator \
-    --username "${AC_USERNAME}" \
+xcrun notarytool submit \
+    --apple-id "${AC_USERNAME}" \
+    --team-id 'Y3W4TDQXXQ' \
     --password "${AC_PASSWORD}" \
-    --file keyboard-configurator.dmg
+    --wait \
+    keyboard-configurator.dmg
 
 # Try to staple notarization
 set +e


### PR DESCRIPTION
The old method is deprecated and will stop working.

Tested locally and on CI (https://github.com/pop-os/keyboard-configurator/actions/runs/5417755882/jobs/9849071138). Seems to work.