### PR TITLE
linux: Fix AppImage build

### DIFF
--- a/linux/build.py
+++ b/linux/build.py
@@ -60,4 +60,4 @@ subprocess.check_call([f"./{LINUXDEPLOY}",
                        f"--icon-file={ICON}",
                         "--plugin", "gtk",
                         "--output", "appimage"])
-shutil.move(glob.glob(f"System76_Keyboard_Configurator-*-{ARCH}.AppImage")[0], f"{PKG}-{ARCH}.AppImage")
+shutil.move(f"System76_Keyboard_Configurator-{ARCH}.AppImage", f"{PKG}-{ARCH}.AppImage")


### PR DESCRIPTION
It seems the filename of the generated AppImage was changed after an update to `LinuxDeploy`. Easy enough to fix.