### PR TITLE
Use consistent order for json keymap exports

### DIFF
--- a/backend/src/board.rs
+++ b/backend/src/board.rs
@@ -3,7 +3,7 @@ use once_cell::sync::{Lazy, OnceCell};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     process::Command,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -245,8 +245,8 @@ impl Board {
     }
 
     pub fn export_keymap(&self) -> KeyMap {
-        let mut map = HashMap::new();
-        let mut key_leds = HashMap::new();
+        let mut map = BTreeMap::new();
+        let mut key_leds = BTreeMap::new();
         for key in self.keys().iter() {
             let scancodes = (0..self.layout().meta.num_layers as usize)
                 .map(|layer| key.get_scancode(layer).unwrap().1)

--- a/backend/src/keymap.rs
+++ b/backend/src/keymap.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     convert::TryFrom,
     io::{Read, Write},
 };
@@ -24,20 +24,20 @@ mod hs_map_serde {
     use super::*;
 
     pub fn serialize<S: Serializer>(
-        map: &HashMap<String, Option<Hs>>,
+        map: &BTreeMap<String, Option<Hs>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         let map = map
             .iter()
             .map(|(k, hs)| (k, hs.map(|hs| hs.to_ints())))
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
         map.serialize(serializer)
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
-    ) -> Result<HashMap<String, Option<Hs>>, D::Error> {
-        let map = <HashMap<String, Option<(u8, u8)>>>::deserialize(deserializer)?;
+    ) -> Result<BTreeMap<String, Option<Hs>>, D::Error> {
+        let map = <BTreeMap<String, Option<(u8, u8)>>>::deserialize(deserializer)?;
         Ok(map
             .into_iter()
             .map(|(k, v)| (k, v.map(|(h, s)| Hs::from_ints(h, s))))
@@ -57,9 +57,9 @@ pub struct KeyMapLayer {
 pub struct KeyMap {
     pub model: String,
     pub version: u8,
-    pub map: HashMap<String, Vec<String>>,
+    pub map: BTreeMap<String, Vec<String>>,
     #[serde(with = "hs_map_serde")]
-    pub key_leds: HashMap<String, Option<Hs>>,
+    pub key_leds: BTreeMap<String, Option<Hs>>,
     pub layers: Vec<KeyMapLayer>,
 }
 


### PR DESCRIPTION
Fixes https://github.com/pop-os/keyboard-configurator/issues/188.