### PR TITLE
chore: update to gtk-rs v0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,12 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-
-[[package]]
 name = "approx"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,21 +176,20 @@ dependencies = [
 
 [[package]]
 name = "atk"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba16453d10c712284061a05f6510f75abeb92b56ba88dfeb48c74775020cc22"
+checksum = "b4af014b17dd80e8af9fa689b2d4a211ddba6eb583c1622f35d0cb543f6b17e4"
 dependencies = [
  "atk-sys",
- "bitflags 1.3.2",
  "glib",
  "libc",
 ]
 
 [[package]]
 name = "atk-sys"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf0a7ca572fbd5762fd8f8cd65a581e06767bc1234913fe1f43e370cff6e90"
+checksum = "251e0b7d90e33e0ba930891a505a9a35ece37b2dd37a14f3ffc306c13b980009"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -278,11 +271,11 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cairo-rs"
-version = "0.17.10"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3603c4028a5e368d09b51c8b624b9a46edcd7c3778284077a6125af73c9f0a"
+checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -292,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-sys-rs"
-version = "0.17.10"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691d0c66b1fb4881be80a760cb8fe76ea97218312f9dfe2c9cc0f496ca279cb1"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
  "glib-sys",
  "libc",
@@ -701,11 +694,10 @@ dependencies = [
 
 [[package]]
 name = "gdk"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1df5ea52cccd7e3a0897338b5564968274b52f5fd12601e0afa44f454c74d3"
+checksum = "f5ba081bdef3b75ebcdbfc953699ed2d7417d6bd853347a42a37d76406a33646"
 dependencies = [
- "bitflags 1.3.2",
  "cairo-rs",
  "gdk-pixbuf",
  "gdk-sys",
@@ -717,11 +709,10 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf"
-version = "0.17.10"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "695d6bc846438c5708b07007537b9274d883373dd30858ca881d7d71b5540717"
+checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
 dependencies = [
- "bitflags 1.3.2",
  "gdk-pixbuf-sys",
  "gio",
  "glib",
@@ -731,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf-sys"
-version = "0.17.10"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9285ec3c113c66d7d0ab5676599176f1f42f4944ca1b581852215bf5694870cb"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
 dependencies = [
  "gio-sys",
  "glib-sys",
@@ -744,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-sys"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2152de9d38bc67a17b3fe49dc0823af5bf874df59ea088c5f28f31cf103de703"
+checksum = "31ff856cb3386dae1703a920f803abafcc580e9b5f711ca62ed1620c25b51ff2"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -793,11 +784,10 @@ dependencies = [
 
 [[package]]
 name = "gio"
-version = "0.17.10"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6973e92937cf98689b6a054a9e56c657ed4ff76de925e36fc331a15f0c5d30a"
+checksum = "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73"
 dependencies = [
- "bitflags 1.3.2",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -813,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.17.10"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ccf87c30a12c469b6d958950f6a9c09f2be20b7773f7e70d20b867fdf2628c3"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -826,11 +816,11 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.17.10"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fad45ba8d4d2cea612b432717e834f48031cd8853c8aaf43b2c79fec8d144b"
+checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -849,30 +839,29 @@ dependencies = [
 
 [[package]]
 name = "glib-build-tools"
-version = "0.17.10"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a65d79efe318ef2cbbbb37032b125866fd82c34ea44c816132621bbc552e716"
+checksum = "3431c56f463443cba9bc3600248bc6d680cb614c2ee1cdd39dab5415bd12ac5c"
 
 [[package]]
 name = "glib-macros"
-version = "0.17.10"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca5c79337338391f1ab8058d6698125034ce8ef31b72a442437fa6c8580de26"
+checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
- "anyhow",
  "heck",
- "proc-macro-crate",
+ "proc-macro-crate 2.0.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "glib-sys"
-version = "0.17.10"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80aa6ea7bba0baac79222204aa786a6293078c210abe69ef1336911d4bdc4f0"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
  "system-deps",
@@ -880,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.17.10"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd34c3317740a6358ec04572c1bcfd3ac0b5b6529275fae255b237b314bb8062"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
  "glib-sys",
  "libc",
@@ -891,12 +880,11 @@ dependencies = [
 
 [[package]]
 name = "gtk"
-version = "0.17.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c4222ab92b08d4d0bab90ddb6185b4e575ceeea8b8cdf00b938d7b6661d966"
+checksum = "93c4f5e0e20b60e10631a5f06da7fe3dda744b05ad0ea71fee2f47adf865890c"
 dependencies = [
  "atk",
- "bitflags 1.3.2",
  "cairo-rs",
  "field-offset",
  "futures-channel",
@@ -907,16 +895,15 @@ dependencies = [
  "gtk-sys",
  "gtk3-macros",
  "libc",
- "once_cell",
  "pango",
  "pkg-config",
 ]
 
 [[package]]
 name = "gtk-sys"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8eb6a4b93e5a7e6980f7348d08c1cd93d31fae07cf97f20678c5ec41de3d7e"
+checksum = "771437bf1de2c1c0b496c11505bdf748e26066bbe942dfc8f614c9460f6d7722"
 dependencies = [
  "atk-sys",
  "cairo-sys-rs",
@@ -932,16 +919,15 @@ dependencies = [
 
 [[package]]
 name = "gtk3-macros"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3efb84d682c9a39c10bd9f24f5a4b9c15cc8c7edc45c19cb2ca2c4fc38b2d95e"
+checksum = "c6063efb63db582968fb7df72e1ae68aa6360dcfb0a75143f34fc7d616bad75e"
 dependencies = [
- "anyhow",
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1330,11 +1316,10 @@ dependencies = [
 
 [[package]]
 name = "pango"
-version = "0.17.10"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35be456fc620e61f62dff7ff70fbd54dcbaf0a4b920c0f16de1107c47d921d48"
+checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
 dependencies = [
- "bitflags 1.3.2",
  "gio",
  "glib",
  "libc",
@@ -1344,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "pango-sys"
-version = "0.17.10"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da69f9f3850b0d8990d462f8c709561975e95f689c1cdf0fecdebde78b35195"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1356,11 +1341,10 @@ dependencies = [
 
 [[package]]
 name = "pangocairo"
-version = "0.17.10"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bf29cb1c2e73817944f66011fb12135e1c6d268e8e4c5cfc689101c25822cf"
+checksum = "57036589a9cfcacf83f9e606d15813fc6bf03f0e9e69aa2b5e3bb85af86b38a5"
 dependencies = [
- "bitflags 1.3.2",
  "cairo-rs",
  "glib",
  "libc",
@@ -1370,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "pangocairo-sys"
-version = "0.17.10"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94dfd38d9bf8ff5f881be2107ba49fcb22090d247aa00133f8dadf96b122b97a"
+checksum = "fc3c8ff676a37e7a72ec1d5fc029f91c407278083d2752784ff9f5188c108833"
 dependencies = [
  "cairo-sys-rs",
  "glib-sys",
@@ -1507,6 +1491,16 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
+dependencies = [
+ "toml_datetime",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -2476,7 +2470,7 @@ version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d1794a946878c0e807f55a397187c11fc7a038ba5d868e7db4f3bd7760bc9d"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -2515,7 +2509,7 @@ version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [ "tools", "ffi", "backend", "widgets" ]
 [dependencies]
 cascade = "1"
 futures = "0.3.13"
-gtk = { version = "0.17.0" }
+gtk = { version = "0.18.0" }
 libc = "0.2"
 once_cell = "1.4"
-pangocairo = "0.17.0"
+pangocairo = "0.18.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4.0"
@@ -29,7 +29,7 @@ i18n-embed-fl = "0.6.0"
 rust-embed = { version = "6.2.0", features = ["debug-embed"] }
 
 [build-dependencies]
-glib-build-tools = "0.17.0"
+glib-build-tools = "0.18.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.8"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -10,7 +10,7 @@ async-process = "1.7.0"
 cascade = "1"
 futures = { version = "0.3.13", features = ["thread-pool"] }
 futures-timer = "3.0.2"
-glib = { version = "0.17.0", optional = true }
+glib = { version = "0.18.0", optional = true }
 hidapi = { version = "1.2", default-features = false, features = ["linux-shared-hidraw"] }
 libc = "0.2"
 once_cell = "1.4"

--- a/backend/src/benchmark/usb_dev.rs
+++ b/backend/src/benchmark/usb_dev.rs
@@ -18,14 +18,14 @@ impl UsbDev {
 
     pub fn vendor_id(&self) -> io::Result<u16> {
         let vid_path = self.path().join("idVendor");
-        let vid_str = fs::read_to_string(&vid_path)?;
+        let vid_str = fs::read_to_string(vid_path)?;
         u16::from_str_radix(vid_str.trim(), 16)
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
     }
 
     pub fn product_id(&self) -> io::Result<u16> {
         let pid_path = self.path().join("idProduct");
-        let pid_str = fs::read_to_string(&pid_path)?;
+        let pid_str = fs::read_to_string(pid_path)?;
         u16::from_str_radix(pid_str.trim(), 16)
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
     }
@@ -46,10 +46,10 @@ impl UsbDev {
         let mut hosts = Vec::new();
         for (_iface_name, iface_path) in ifaces.iter() {
             let host_prefix = "host";
-            for entry_res in fs::read_dir(&iface_path)? {
+            for entry_res in fs::read_dir(iface_path)? {
                 let entry = entry_res?;
                 if let Ok(entry_name) = entry.file_name().into_string() {
-                    if entry_name.starts_with(&host_prefix) {
+                    if entry_name.starts_with(host_prefix) {
                         hosts.push((entry_name, entry.path()));
                     }
                 }
@@ -60,7 +60,7 @@ impl UsbDev {
         for (host_name, host_path) in hosts.iter() {
             let host_id = host_name.trim_start_matches("host");
             let target_prefix = format!("target{}:", host_id);
-            for entry_res in fs::read_dir(&host_path)? {
+            for entry_res in fs::read_dir(host_path)? {
                 let entry = entry_res?;
                 if let Ok(entry_name) = entry.file_name().into_string() {
                     if entry_name.starts_with(&target_prefix) {
@@ -74,7 +74,7 @@ impl UsbDev {
         for (target_name, target_path) in targets.iter() {
             let target_id = target_name.trim_start_matches("target");
             let disk_prefix = format!("{}:", target_id);
-            for entry_res in fs::read_dir(&target_path)? {
+            for entry_res in fs::read_dir(target_path)? {
                 let entry = entry_res?;
                 if let Ok(entry_name) = entry.file_name().into_string() {
                     if entry_name.starts_with(&disk_prefix) {

--- a/backend/src/layout/mod.rs
+++ b/backend/src/layout/mod.rs
@@ -90,6 +90,7 @@ macro_rules! keyboards {
 include!(concat!(env!("OUT_DIR"), "/keyboards.rs"));
 
 impl Layout {
+    #[allow(clippy::too_many_arguments)]
     pub fn from_data(
         board: &str,
         meta_json: &str,

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -9,5 +9,5 @@ name = "system76_keyboard_configurator"
 crate-type = [ "cdylib" ]
 
 [dependencies]
-gtk = "0.17.0"
+gtk = "0.18.0"
 system76-keyboard-configurator-widgets = { path = "../widgets" }

--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -12,6 +12,6 @@ fn main() {
 
     File::create(target_dir.join("system76_keyboard_configurator.pc.stub"))
         .expect("failed to create pc.stub")
-        .write_all(&pkg_config.as_bytes())
+        .write_all(pkg_config.as_bytes())
         .expect("failed to write pc.stub");
 }

--- a/src/backlight.rs
+++ b/src/backlight.rs
@@ -337,7 +337,7 @@ impl Backlight {
         let board = self.board().clone();
         let speed = self.inner().speed_scale.value();
         let mode = self.mode();
-        let layer = self.inner().layer.get() as usize;
+        let layer = self.inner().layer.get();
         glib::MainContext::default().spawn_local(async move {
             let layer = &board.layers()[layer];
             if let Err(err) = layer.set_mode(mode, speed as u8).await {

--- a/src/backlight.rs
+++ b/src/backlight.rs
@@ -2,7 +2,7 @@ use crate::fl;
 use cascade::cascade;
 use futures::{prelude::*, stream::FuturesUnordered};
 use gtk::{
-    glib::{self, clone},
+    glib::{self, clone, ControlFlow},
     prelude::*,
     subclass::prelude::*,
 };
@@ -251,9 +251,9 @@ impl Backlight {
         if has_led_save {
             glib::timeout_add_seconds_local(
                 10,
-                clone!(@weak obj => @default-return Continue(false), move || {
+                clone!(@weak obj => @default-return ControlFlow::Break, move || {
                     obj.led_save();
-                    Continue(true)
+                    ControlFlow::Continue
                 }),
             );
         }

--- a/src/configurator_app.rs
+++ b/src/configurator_app.rs
@@ -132,7 +132,7 @@ impl ApplicationImpl for ConfiguratorAppInner {
             info!("Focusing current window");
             window.present();
         } else {
-            MainWindow::new(&*self.obj());
+            MainWindow::new(&self.obj());
         }
     }
 }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -413,7 +413,7 @@ impl Keyboard {
 
         if chooser.run() == gtk::ResponseType::Accept {
             let path = chooser.filename().unwrap();
-            match File::open(&path) {
+            match File::open(path) {
                 Ok(file) => match KeyMap::from_reader(file) {
                     Ok(keymap) => {
                         let self_ = self.clone();
@@ -452,11 +452,11 @@ impl Keyboard {
                 show_error_dialog(
                     &self.window().unwrap(),
                     &fl!("error-unsupported-keymap"),
-                    &fl!("error-unsupported-keymap-desc"),
+                    fl!("error-unsupported-keymap-desc"),
                 )
             }
 
-            match File::create(&path) {
+            match File::create(path) {
                 Ok(file) => match keymap.to_writer_pretty(file) {
                     Ok(()) => {}
                     Err(err) => {
@@ -567,7 +567,7 @@ impl Keyboard {
         *self.inner().picker.borrow_mut() = match picker {
             Some(picker) => {
                 self.inner().picker_box.add(picker);
-                picker.set_sensitive(!self.selected().is_empty() && self.layer() != None);
+                picker.set_sensitive(!self.selected().is_empty() && self.layer().is_some());
                 picker.downgrade()
             }
             None => WeakRef::new(),
@@ -595,7 +595,7 @@ impl Keyboard {
         }
         picker.set_selected(selected_scancodes);
 
-        picker.set_sensitive(selected.len() > 0 && self.layer() != None);
+        picker.set_sensitive(selected.len() > 0 && self.layer().is_some());
 
         self.inner().selected.replace(selected);
 

--- a/src/keyboard_layer.rs
+++ b/src/keyboard_layer.rs
@@ -1,5 +1,5 @@
 use cascade::cascade;
-use gtk::{cairo, gdk, glib, pango, prelude::*, subclass::prelude::*};
+use gtk::{cairo, gdk, glib, glib::Propagation, pango, prelude::*, subclass::prelude::*};
 use once_cell::unsync::OnceCell;
 use std::{
     cell::{Cell, RefCell},
@@ -77,7 +77,7 @@ impl ObjectImpl for KeyboardLayerInner {
 }
 
 impl WidgetImpl for KeyboardLayerInner {
-    fn draw(&self, cr: &cairo::Context) -> Inhibit {
+    fn draw(&self, cr: &cairo::Context) -> Propagation {
         self.parent_draw(cr);
 
         let selected = Rgb::new(0xfb, 0xb8, 0x6c).to_floats();
@@ -148,14 +148,14 @@ impl WidgetImpl for KeyboardLayerInner {
             pangocairo::show_layout(cr, &layout);
         }
 
-        Inhibit(false)
+        Propagation::Proceed
     }
 
-    fn button_press_event(&self, evt: &gdk::EventButton) -> Inhibit {
+    fn button_press_event(&self, evt: &gdk::EventButton) -> Propagation {
         self.parent_button_press_event(evt);
 
         if !self.selectable.get() {
-            return Inhibit(false);
+            return Propagation::Proceed;
         }
 
         let pos = evt.position();
@@ -183,7 +183,7 @@ impl WidgetImpl for KeyboardLayerInner {
             self.obj().set_selected(selected);
         }
 
-        Inhibit(false)
+        Propagation::Proceed
     }
 
     fn request_mode(&self) -> gtk::SizeRequestMode {

--- a/src/main_window.rs
+++ b/src/main_window.rs
@@ -3,7 +3,7 @@ use cascade::cascade;
 use futures::StreamExt;
 use gtk::{
     gio,
-    glib::{self, clone},
+    glib::{self, clone, ControlFlow},
     pango,
     prelude::*,
     subclass::prelude::*,
@@ -274,7 +274,7 @@ impl MainWindow {
         window.inner().is_testing_mode.set(is_testing_mode);
         glib::timeout_add_seconds_local(
             1,
-            clone!(@weak window => @default-return glib::Continue(false), move || {
+            clone!(@weak window => @default-return ControlFlow::Break, move || {
                 if !REFRESH_DISABLED.load(Ordering::Relaxed) {
                   let inner = window.inner();
                   inner.backend.refresh();
@@ -282,7 +282,7 @@ impl MainWindow {
                       inner.backend.check_for_bootloader()
                   }
                 }
-                glib::Continue(true)
+                ControlFlow::Continue
             }),
         );
 

--- a/src/picker/mod.rs
+++ b/src/picker/mod.rs
@@ -158,7 +158,7 @@ mod tests {
         for i in layouts() {
             let layout = Layout::from_board(i, "dummy").unwrap();
             for j in layout.default.map.values().flatten() {
-                if SCANCODE_LABELS.keys().find(|x| x == &j).is_none() {
+                if !SCANCODE_LABELS.keys().any(|x| x == j) {
                     missing.insert(j.to_owned());
                 }
             }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -3,7 +3,7 @@ use backend::{Board, DerefCell, NelsonKind, Rgb};
 use cascade::cascade;
 use futures::channel::oneshot;
 use gtk::{
-    glib::{self, clone},
+    glib::{self, clone, Propagation},
     prelude::*,
     subclass::prelude::*,
 };
@@ -109,7 +109,7 @@ impl ObjectImpl for TestingInner {
                 ..connect_draw(move |_w, cr| {
                     cr.set_source_rgb(r, g, b);
                     cr.paint().unwrap();
-                    Inhibit(false)
+                    Propagation::Proceed
                 });
             }
         }

--- a/tools/src/pkgconfig.rs
+++ b/tools/src/pkgconfig.rs
@@ -20,7 +20,7 @@ fn main() -> io::Result<()> {
     fs::create_dir_all("target/")?;
 
     let target = ["target/", &app, ".pc"].concat();
-    let mut file = File::create(&target).expect("unable to create pkgconfig file");
+    let mut file = File::create(target).expect("unable to create pkgconfig file");
 
     writeln!(
         &mut file,

--- a/widgets/Cargo.toml
+++ b/widgets/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 cascade = "1"
 futures = "0.3.13"
-gtk = { version = "0.17.0" }
+gtk = { version = "0.18.0" }
 libc = "0.2"
 once_cell = "1.4"
 serde = { version = "1.0", features = ["derive"] }
@@ -22,7 +22,7 @@ i18n-embed-fl = "0.6.0"
 rust-embed = { version = "6.2.0", features = ["debug-embed"] }
 
 [build-dependencies]
-gio = "0.17.0"
+gio = "0.18.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.8"

--- a/widgets/src/choose_color.rs
+++ b/widgets/src/choose_color.rs
@@ -3,7 +3,7 @@ use cascade::cascade;
 use futures::future::abortable;
 use gtk::{
     gio,
-    glib::{self, clone},
+    glib::{self, clone, Propagation},
     prelude::*,
 };
 use std::{cell::RefCell, rc::Rc};
@@ -38,7 +38,7 @@ pub async fn choose_color<W: IsA<gtk::Widget>>(
             let (r, g, b) = color_wheel.hs().to_rgb().to_floats();
             cr.set_source_rgb(r, g, b);
             cr.paint().unwrap();
-            Inhibit(false)
+            Propagation::Proceed
         }));
     };
 

--- a/widgets/src/color_circle.rs
+++ b/widgets/src/color_circle.rs
@@ -1,5 +1,5 @@
 use cascade::cascade;
-use gtk::{cairo, glib, prelude::*, subclass::prelude::*};
+use gtk::{cairo, glib, glib::Propagation, prelude::*, subclass::prelude::*};
 use std::{cell::RefCell, collections::BTreeSet, f64::consts::PI};
 
 use backend::Hs;
@@ -21,7 +21,7 @@ impl ObjectSubclass for ColorCircleInner {
 impl ObjectImpl for ColorCircleInner {}
 
 impl WidgetImpl for ColorCircleInner {
-    fn draw(&self, cr: &cairo::Context) -> Inhibit {
+    fn draw(&self, cr: &cairo::Context) -> Propagation {
         let width = f64::from(self.obj().allocated_width());
         let height = f64::from(self.obj().allocated_height());
 
@@ -58,7 +58,7 @@ impl WidgetImpl for ColorCircleInner {
         cr.set_source_rgb(0.5, 0.5, 0.5);
         cr.stroke().unwrap();
 
-        Inhibit(false)
+        Propagation::Proceed
     }
 }
 

--- a/widgets/src/color_wheel.rs
+++ b/widgets/src/color_wheel.rs
@@ -4,7 +4,7 @@ use cascade::cascade;
 use futures::future::{abortable, AbortHandle};
 use gtk::{
     cairo, gdk,
-    glib::{self, clone},
+    glib::{self, clone, Propagation},
     prelude::*,
     subclass::prelude::*,
 };
@@ -111,7 +111,7 @@ impl ObjectImpl for ColorWheelInner {
 }
 
 impl WidgetImpl for ColorWheelInner {
-    fn draw(&self, cr: &cairo::Context) -> Inhibit {
+    fn draw(&self, cr: &cairo::Context) -> Propagation {
         self.parent_draw(cr);
 
         let width = f64::from(self.obj().allocated_width());
@@ -146,7 +146,7 @@ impl WidgetImpl for ColorWheelInner {
         cr.set_line_width(1.);
         cr.stroke().unwrap();
 
-        Inhibit(false)
+        Propagation::Proceed
     }
 
     fn size_allocate(&self, rect: &gdk::Rectangle) {

--- a/widgets/src/keyboard_backlight_widget.rs
+++ b/widgets/src/keyboard_backlight_widget.rs
@@ -4,7 +4,7 @@ use crate::fl;
 use cascade::cascade;
 use futures::StreamExt;
 use gtk::{
-    glib::{self, clone},
+    glib::{self, clone, Propagation},
     prelude::*,
 };
 
@@ -65,7 +65,7 @@ fn page(board: Board) -> gtk::Widget {
                     eprintln!("{}: {}", fl!("error-set-brightness"), err);
                 }
             }));
-            Inhibit(false)
+            Propagation::Proceed
         }));
     };
 

--- a/widgets/src/keyboard_color.rs
+++ b/widgets/src/keyboard_color.rs
@@ -27,11 +27,11 @@ impl KeyboardColorIndex {
             KeyboardColorIndex::Keys(keys) => {
                 let futures = FuturesUnordered::new();
                 for i in keys.iter() {
-                    futures.push(board.keys()[*i as usize].set_color(Some(hs)));
+                    futures.push(board.keys()[*i].set_color(Some(hs)));
                 }
                 futures.try_collect::<()>().await?
             }
-            KeyboardColorIndex::Layer(i) => board.layers()[*i as usize].set_color(hs).await?,
+            KeyboardColorIndex::Layer(i) => board.layers()[*i].set_color(hs).await?,
         };
         Ok(())
     }
@@ -40,11 +40,11 @@ impl KeyboardColorIndex {
         match self {
             KeyboardColorIndex::Keys(keys) => keys
                 .iter()
-                .filter_map(|i| board.keys()[*i as usize].color())
+                .filter_map(|i| board.keys()[*i].color())
                 .collect(),
             KeyboardColorIndex::Layer(i) => cascade! {
                 BTreeSet::new();
-                ..insert(board.layers()[*i as usize].color());
+                ..insert(board.layers()[*i].color());
             },
         }
     }
@@ -71,12 +71,12 @@ impl KeyboardColorIndex {
             KeyboardColorIndex::Keys(keys) => {
                 let futures = FuturesUnordered::new();
                 for i in keys.iter() {
-                    futures.push(board.keys()[*i as usize].set_color(colors.get(i).copied()));
+                    futures.push(board.keys()[*i].set_color(colors.get(i).copied()));
                 }
                 futures.try_collect::<()>().await?
             }
             KeyboardColorIndex::Layer(i) => {
-                board.layers()[*i as usize]
+                board.layers()[*i]
                     .set_color(*colors.get(i).unwrap())
                     .await?
             }


### PR DESCRIPTION
The first commit in this PR ports keyboard-configurator to v0.18 of gtk-rs, which is apparently also going to be the last version of gtk-rs that will have GTK3 bindings. The second commit fixes all the clippy warnings that have been introduced in recent versions of Rust.

The first part was split off from https://github.com/pop-os/keyboard-configurator/pull/221 since gtk-rs v0.18 is not available on all targeted distributions yet.

I'm not in a hurry to get this landed, I'm just posting it as a separate PR since I already did the work and it might be useful for you in the future.