### PR TITLE
windows: Fix `build.py` with latest msys2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     - uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW32
-        install: mingw-w64-i686-gtk3 mingw-w64-i686-rust mingw-w64-i686-toolchain mingw-w64-i686-ntldd mingw-w64-i686-imagemagick
+        install: mingw-w64-i686-gtk3 mingw-w64-i686-rust mingw-w64-i686-toolchain mingw-w64-i686-ntldd mingw-w64-x86_64-imagemagick
     - uses: actions/checkout@v2
     - name: Build and package
       shell: msys2 {0}

--- a/windows/README.md
+++ b/windows/README.md
@@ -8,7 +8,7 @@
 - [MSYS2](https://www.msys2.org/)
 - [WiX Toolset](https://wixtoolset.org/)
 
-In msys2, run `pacman -S ingw-w64-i686-gtk3 mingw-w64-i686-rust mingw-w64-i686-toolchain mingw-w64-i686-ntldd mingw-w64-i686-imagemagick`.
+In msys2, run `pacman -S mingw-w64-i686-gtk3 mingw-w64-i686-rust mingw-w64-i686-toolchain mingw-w64-i686-ntldd mingw-w64-x86_64-imagemagick`.
 
 ### Building
 `.\build.bat` will build and generate a `.msi` installer.

--- a/windows/build.bat
+++ b/windows/build.bat
@@ -1,1 +1,2 @@
+set MSYSTEM_PREFIX=C:\msys64\mingw32
 C:\msys64\mingw32\bin\python build.py

--- a/windows/build.py
+++ b/windows/build.py
@@ -29,6 +29,10 @@ ICON = "../data/icons/scalable/apps/com.system76.keyboardconfigurator.svg"
 
 DLL_RE = r"(?<==> )(.*\\mingw32)\\bin\\(\S+.dll)"
 
+# mingw32 version seems to no longer be packaged, and need to avoid unrelated
+# System32/convert
+CONVERT = os.path.dirname(os.environ['MSYSTEM_PREFIX']) + r'\mingw64\bin\convert.exe'
+
 ADWAITA_FILES = [
     'index.theme',
     'symbolic/actions/open-menu-symbolic.svg',
@@ -119,11 +123,11 @@ crate_version = package['version']
 
 # Generate Icon and installer banner
 subprocess.check_call(["rsvg-convert", "--width", "256", "--height", "256", "-o", "keyboard-configurator.png", ICON])
-subprocess.check_call(["convert", "keyboard-configurator.png", "out/keyboard-configurator.ico"])
+subprocess.check_call([CONVERT, "keyboard-configurator.png", "out/keyboard-configurator.ico"])
 subprocess.check_call(["rsvg-convert", "--width", "493", "--height", "58", "-o", "banner.png", "banner.svg"])
-subprocess.check_call(["convert", "banner.png", "banner.bmp"])
+subprocess.check_call([CONVERT, "banner.png", "banner.bmp"])
 subprocess.check_call(["rsvg-convert", "--width", "493", "--height", "312", "-o", "dialog.png", "dialog.svg"])
-subprocess.check_call(["convert", "dialog.png", "dialog.bmp"])
+subprocess.check_call([CONVERT, "dialog.png", "dialog.bmp"])
 
 # Generate libraries.wxi
 with open('libraries.wxi', 'w') as f:


### PR DESCRIPTION
It seems msys2 is no-longer packaging a 32-bit version of imagemagick. (But it's only a build dependency, so that's not a problem.)

I also see it using `C:\windows\system32\convert.exe` (an unrelated program) in some cases, even when `which` lists a different version? Odd, unless that was just caching.

Anyway, this installs and uses the right version.

This only changes the Windows build script and CI, so it won't impact behavior elsewhere.