### PR TITLE
Version 1.3.12, with arm64 macOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
     - run: '& "C:\Program Files (x86)\System76\Keyboard Configurator\system76-keyboard-configurator.exe" --help-gtk'
 
   macos:
-    # TODO: `macos-14` runner uses Apple Silicon
     runs-on: macos-13
     steps:
     - run: brew install gtk+3 imagemagick librsvg adwaita-icon-theme
@@ -108,10 +107,44 @@ jobs:
     - run: '"./mnt/System76 Keyboard Configurator.app/Contents/MacOS/keyboard-configurator" --help-gtk'
     - run: 'open "mnt/System76 Keyboard Configurator.app" --args --help-gtk'
 
+  # `macos-14` runner uses Apple Silicon
+  macos-arm64:
+    runs-on: macos-14
+    steps:
+    - run: brew install gtk+3 imagemagick librsvg adwaita-icon-theme
+    - run: npm install -g appdmg
+    - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+    - uses: actions/checkout@v2
+    - env:
+        AC_PASSWORD: ${{ github.event_name == 'release' && secrets.AC_PASSWORD || '' }}
+        AC_USERNAME: ${{ github.event_name == 'release' && secrets.AC_USERNAME || '' }}
+        MACOS_CERTIFICATE: ${{ github.event_name == 'release' && secrets.MACOS_CERTIFICATE || '' }}
+        MACOS_SCRIPT: ${{ github.event_name == 'release' && 'bash ./signing.sh' || 'python3 ./build.py' }}
+      run: cd macos && $MACOS_SCRIPT $RELEASE
+    - run: mv macos/keyboard-configurator.dmg macos/keyboard-configurator-arm64.dmg
+    - uses: actions/upload-artifact@v2
+      with:
+        if-no-files-found: error
+        name: keyboard-configurator-macos-arm64-${{ github.sha }}
+        path: macos/keyboard-configurator-arm64.dmg
+
+  macos-arm64-test:
+    runs-on: macos-14
+    needs: macos-arm64
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: keyboard-configurator-macos-arm64-${{ github.sha }}
+    - run: mkdir mnt && hdiutil attach keyboard-configurator-arm64.dmg -mountpoint $PWD/mnt
+    - run: '"./mnt/System76 Keyboard Configurator.app/Contents/MacOS/keyboard-configurator" --help-gtk'
+    - run: 'open "mnt/System76 Keyboard Configurator.app" --args --help-gtk'
+
+
+
   upload-to-release:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
-    needs: [linux-x86_64, windows-mingw32, macos]
+    needs: [linux-x86_64, windows-mingw32, macos, macos-arm64]
     steps:
     - uses: actions/checkout@v2
     - run: echo VERSION=$(./.github/workflows/version.py) > $GITHUB_ENV
@@ -139,4 +172,12 @@ jobs:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: keyboard-configurator-macos-${{ github.sha }}/keyboard-configurator.dmg
         asset_name: keyboard-configurator-${{ env.VERSION }}.dmg
+        asset_content_type: application/x-apple-diskimage
+    - uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: keyboard-configurator-macos-arm64-${{ github.sha }}/keyboard-configurator-arm64.dmg
+        asset_name: keyboard-configurator-arm64-${{ env.VERSION }}.dmg
         asset_content_type: application/x-apple-diskimage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "system76-keyboard-configurator"
-version = "1.3.11"
+version = "1.3.12"
 dependencies = [
  "cascade",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system76-keyboard-configurator"
-version = "1.3.11"
+version = "1.3.12"
 authors = ["Ian Douglas Scott <idscott@system76.com>", "Jeremy Soller <jeremy@system76.com>"]
 license = "GPL-3.0-or-later"
 edition = "2021"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-keyboard-configurator (1.3.12) jammy; urgency=medium
+
+  * 1.3.12 release.
+
+ -- Ian Douglas Scott <idscott@system76.com>  Wed, 07 Aug 2024 10:24:27 -0700
+
 system76-keyboard-configurator (1.3.11) jammy; urgency=medium
 
   * 1.3.11 release.

--- a/macos/deploy.py
+++ b/macos/deploy.py
@@ -1,4 +1,5 @@
 import hashlib
+import platform
 import os
 import re
 import shutil
@@ -7,7 +8,10 @@ import subprocess
 APPDIR = 'System76 Keyboard Configurator.app'
 BINDIR = APPDIR + '/Contents/MacOS'
 RESOURCEDIR = APPDIR + '/Contents/Resources'
-PREFIX = '/usr/local'
+if platform.machine() == 'arm64':
+    PREFIX = '/opt/homebrew'
+else:
+    PREFIX = '/usr/local'
 
 ADWAITA_FILES = [
     'index.theme',

--- a/macos/launcher.sh
+++ b/macos/launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# From https://gitlab.gnome.org/GNOME/gtk-mac-bundler/-/blob/master/examples/launcher.sh
+# https://gitlab.gnome.org/GNOME/gtk-mac-bundler/-/blob/master/examples/gtk3-launcher.sh
 
 if test "x$GTK_DEBUG_LAUNCHER" != x; then
     set -x
@@ -30,15 +30,10 @@ export GTK_DATA_PREFIX="$bundle_res"
 export GTK_EXE_PREFIX="$bundle_res"
 export GTK_PATH="$bundle_res"
 
-export GTK2_RC_FILES="$bundle_etc/gtk-2.0/gtkrc"
-export GTK_IM_MODULE_FILE="$bundle_etc/gtk-2.0/gtk.immodules"
-#N.B. When gdk-pixbuf was separated from Gtk+ the location of the
-#loaders cache changed as well. Depending on the version of Gtk+ that
-#you built with you may still need to use the old location:
-#export GDK_PIXBUF_MODULE_FILE="$bundle_etc/gtk-2.0/gdk-pixbuf.loaders"
 export GDK_PIXBUF_MODULE_FILE="$bundle_lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
-export PANGO_LIBDIR="$bundle_lib"
-export PANGO_SYSCONFDIR="$bundle_etc"
+if [ `uname -r | cut -d . -f 1` -ge 10 ]; then
+    export GTK_IM_MODULE_FILE="$bundle_lib/gtk-3.0/3.0.0/immodules.cache"
+fi
 
 APP=$name
 I18NDIR="$bundle_data/locale"
@@ -53,39 +48,39 @@ if test "$APPLELANGUAGES"; then
     # A language ordering exists.
     # Test, item per item, to see whether there is an corresponding locale.
     for L in $APPLELANGUAGES; do
-	#test for exact matches:
+        #test for exact matches:
        if test -f "$I18NDIR/${L}/LC_MESSAGES/$APP.mo"; then
-	    export LANG=$L
+            export LANG=$L
             break
         fi
-	#This is a special case, because often the original strings are in US
-	#English and there is no translation file.
-	if test "x$L" == "xen_US"; then
-	    export LANG=$L
-	    break
-	fi
-	#OK, now test for just the first two letters:
+        # This is a special case, because often the original strings are in US
+        # English and there is no translation file.
+        if test "x$L" == "xen_US"; then
+            export LANG=$L
+            break
+        fi
+        #OK, now test for just the first two letters:
         if test -f "$I18NDIR/${L:0:2}/LC_MESSAGES/$APP.mo"; then
-	    export LANG=${L:0:2}
-	    break
-	fi
-	#Same thing, but checking for any english variant.
-	if test "x${L:0:2}" == "xen"; then
-	    export LANG=$L
-	    break
-	fi;
-    done  
+            export LANG=${L:0:2}
+            break
+        fi
+        #Same thing, but checking for any english variant.
+        if test "x${L:0:2}" == "xen"; then
+            export LANG=$L
+            break
+        fi;
+    done
 fi
 unset APPLELANGUAGES L
 
 # If we didn't get a language from the language list, try the Collation preference, in case it's the only setting that exists.
 APPLECOLLATION=`defaults read .GlobalPreferences AppleCollationOrder`
-if test -z ${LANG} -a -n $APPLECOLLATION; then
+if test -z ${LANG} && test -n $APPLECOLLATION; then
     if test -f "$I18NDIR/${APPLECOLLATION:0:2}/LC_MESSAGES/$APP.mo"; then
-	export LANG=${APPLECOLLATION:0:2}
+        export LANG=${APPLECOLLATION:0:2}
     fi
 fi
-if test ! -z $APPLECOLLATION; then
+if test -n $APPLECOLLATION; then
     export LC_COLLATE=$APPLECOLLATION
 fi
 unset APPLECOLLATION
@@ -94,64 +89,66 @@ unset APPLECOLLATION
 APPLELOCALE=`defaults read .GlobalPreferences AppleLocale`
 
 if test -f "$I18NDIR/${APPLELOCALE:0:5}/LC_MESSAGES/$APP.mo"; then
-    if test -z $LANG; then 
+    if test -z $LANG; then
         export LANG="${APPLELOCALE:0:5}"
     fi
 
-elif test -z $LANG -a -f "$I18NDIR/${APPLELOCALE:0:2}/LC_MESSAGES/$APP.mo"; then
+elif test -z $LANG && test -f "$I18NDIR/${APPLELOCALE:0:2}/LC_MESSAGES/$APP.mo"; then
     export LANG="${APPLELOCALE:0:2}"
 fi
 
-#Next we need to set LC_MESSAGES. If at all possible, we want a full
-#5-character locale to avoid the "Locale not supported by C library"
-#warning from Gtk -- even though Gtk will translate with a
-#two-character code.
-if test -n $LANG; then 
-#If the language code matches the applelocale, then that's the message
-#locale; otherwise, if it's longer than two characters, then it's
-#probably a good message locale and we'll go with it.
-    if test $LANG == ${APPLELOCALE:0:5} -o $LANG != ${LANG:0:2}; then
-	export LC_MESSAGES=$LANG
-#Next try if the Applelocale is longer than 2 chars and the language
-#bit matches $LANG
-    elif test $LANG == ${APPLELOCALE:0:2} -a $APPLELOCALE > ${APPLELOCALE:0:2}; then
-	export LC_MESSAGES=${APPLELOCALE:0:5}
-#Fail. Get a list of the locales in $PREFIX/share/locale that match
-#our two letter language code and pick the first one, special casing
-#english to set en_US
+# Next we need to set LC_MESSAGES. If at all possible, we want a full
+# 5-character locale to avoid the "Locale not supported by C library"
+# warning from Gtk -- even though Gtk will translate with a
+# two-character code.
+if test -n $LANG; then
+    # If the language code matches the applelocale, then that's the message
+    # locale; otherwise, if it's longer than two characters, then it's
+    # probably a good message locale and we'll go with it.
+    if test $LANG == ${APPLELOCALE:0:5} || test $LANG != ${LANG:0:2}; then
+        export LC_MESSAGES=$LANG
+# Next try if the Applelocale is longer than 2 chars and the language
+# bit matches $LANG
+    elif test $LANG == ${APPLELOCALE:0:2} && test $APPLELOCALE > ${APPLELOCALE:0:2}; then
+        export LC_MESSAGES=${APPLELOCALE:0:5}
+    # Fail. Get a list of the locales in $I18DIR that match
+    # our two letter language code and pick the first one, special casing
+    # english to set en_US
     elif test $LANG == "en"; then
-	export LC_MESSAGES="en_US"
+        export LC_MESSAGES="en_US"
     else
-	LOC=`find $PREFIX/share/locale -name $LANG???`
-	for L in $LOC; do 
-	    export LC_MESSAGES=$L
-	done
+        LOC=`find $I18DIR -name $LANG???`
+        for L in $LOC; do
+            export LC_MESSAGES=$L
+        done
     fi
 else
-#All efforts have failed, so default to US english
+    # All efforts have failed, so default to US english
     export LANG="en_US"
     export LC_MESSAGES="en_US"
 fi
 CURRENCY=`echo $APPLELOCALE |  sed -En 's/.*currency=([[:alpha:]]+).*/\1/p'`
-if test "x$CURRENCY" != "x"; then 
-#The user has set a special currency. Gtk doesn't install LC_MONETARY files, but Apple does in /usr/share/locale, so we're going to look there for a locale to set LC_CURRENCY to.
+if test -n "$CURRENCY"; then
+   # The user has set a special currency. Gtk doesn't install
+   # LC_MONETARY files, but Apple does in /usr/share/locale, so we're
+   # going to look there for a locale to set LC_CURRENCY to.
     if test -f /usr/local/share/$LC_MESSAGES/LC_MONETARY; then
-	if test -a `cat /usr/local/share/$LC_MESSAGES/LC_MONETARY` == $CURRENCY; then
-	    export LC_MONETARY=$LC_MESSAGES
-	fi
+        if test `cat /usr/local/share/$LC_MESSAGES/LC_MONETARY` == $CURRENCY; then
+            export LC_MONETARY=$LC_MESSAGES
+        fi
     fi
-    if test -z "$LC_MONETARY"; then 
-	FILES=`find /usr/share/locale -name LC_MONETARY -exec grep -H $CURRENCY {} \;`
-	if test -n "$FILES"; then 
-	    export LC_MONETARY=`echo $FILES | sed -En 's%/usr/share/locale/([[:alpha:]_]+)/LC_MONETARY.*%\1%p'`
-	fi
+    if test -z "$LC_MONETARY"; then
+        FILES=`find /usr/share/locale -name LC_MONETARY -exec grep -H $CURRENCY {} \;`
+        if test -n "$FILES"; then
+            export LC_MONETARY=`echo $FILES | sed -En 's%/usr/share/locale/([[:alpha:]_]+)/LC_MONETARY.*%\1%p'`
+        fi
     fi
 fi
-#No currency value means that the AppleLocale governs:
+# No currency value means that the AppleLocale governs:
 if test -z "$LC_MONETARY"; then
     LC_MONETARY=${APPLELOCALE:0:5}
 fi
-#For Gtk, which only looks at LC_ALL:
+# For Gtk, which only looks at LC_ALL:
 export LC_ALL=$LC_MESSAGES
 
 unset APPLELOCALE FILES LOC
@@ -163,7 +160,7 @@ fi
 # Extra arguments can be added in environment.sh.
 EXTRA_ARGS=
 if test -f "$bundle_res/environment.sh"; then
-  source "$bundle_res/environment.sh"
+    source "$bundle_res/environment.sh"
 fi
 
 # Strip out the argument added by the OS.


### PR DESCRIPTION
The macOS arm64 build here seems to work on an M1 mac, except for signing (is Apple silicon more restrictive about this?). The ad-hoc signature it is signed with seemed to work on the CI signature, but I had to resign locally to run on my system.

This PR doesn't change the Configurator itself or the Debian packaging, except for the version bump. The other changes are to CI and the macOS scripts.